### PR TITLE
Update to include label allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ derek
 *.txt
 auth/*.pem
 
-
+*.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.5
 
 RUN apk --no-cache add curl ca-certificates \ 
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSL https://github.com/alexellis/faas/releases/download/0.6.0/fwatchdog > /usr/bin/fwatchdog \
+    && curl -sSL https://github.com/alexellis/faas/releases/download/0.6.4/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 

--- a/auth/jwt_auth.go
+++ b/auth/jwt_auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"io/ioutil"
 	"time"
 
@@ -9,9 +10,13 @@ import (
 
 // GetSignedJwtToken get a tokens signed with private key
 func GetSignedJwtToken(keyPath string) (string, error) {
+	if len(keyPath) == 0 {
+		return "", fmt.Errorf("unable to read from empty keypath, try setting env: \"private_key\" to a filename and path")
+	}
+
 	keyBytes, err := ioutil.ReadFile(keyPath)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("unable to read keypath: %s, error: %s", keyPath, err)
 	}
 
 	key, keyErr := jwt.ParseRSAPrivateKeyFromPEM(keyBytes)

--- a/commentHandler.go
+++ b/commentHandler.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/alexellis/derek/auth"
+	"github.com/alexellis/derek/types"
+	"github.com/google/go-github/github"
+)
+
+func makeClient() (*github.Client, context.Context) {
+	ctx := context.Background()
+
+	token := os.Getenv("access_token")
+	if len(token) == 0 {
+		newToken, tokenErr := auth.MakeAccessTokenForInstallation(os.Getenv("installation"), os.Getenv("private_key"))
+		if tokenErr != nil {
+			log.Fatalln(tokenErr.Error())
+		}
+
+		token = newToken
+	}
+
+	client := auth.MakeClient(ctx, token)
+
+	return client, ctx
+}
+
+func handleComment(req types.IssueCommentOuter) {
+
+	command := parse(req.Comment.Body)
+	switch command.Type {
+	case "AddLabel":
+		allowed := isMaintainer(req.Comment.User.Login, req.Repository)
+		fmt.Printf("%s wants to %s of %s to issue %d - allowed? %t\n", req.Comment.User.Login, command.Type, command.Value, req.Issue.Number, allowed)
+
+		found := false
+		for _, label := range req.Issue.Labels {
+			if label.Name == command.Value {
+				found = true
+				break
+			}
+		}
+
+		if found == true {
+			fmt.Println("Label already exists.")
+			return
+		}
+
+		if allowed {
+			client, ctx := makeClient()
+			_, _, err := client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, []string{command.Value})
+			if err != nil {
+				log.Fatalln(err)
+			}
+			fmt.Println("Label added successfully or already existed.")
+		}
+		break
+
+	case "RemoveLabel":
+		allowed := isMaintainer(req.Comment.User.Login, req.Repository)
+		fmt.Printf("%s wants to %s of %s to issue %d - allowed? %t\n", req.Comment.User.Login, command.Type, command.Value, req.Issue.Number, allowed)
+
+		found := false
+		for _, label := range req.Issue.Labels {
+			if label.Name == command.Value {
+				found = true
+				break
+			}
+		}
+
+		if found == false {
+			fmt.Println("Label didn't exist on issue.")
+			return
+		}
+
+		if allowed {
+			client, ctx := makeClient()
+			_, err := client.Issues.RemoveLabelForIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, command.Value)
+			if err != nil {
+				log.Fatalln(err)
+			}
+			fmt.Println("Label removed successfully or already removed.")
+		}
+
+		break
+
+	default:
+		log.Fatalln("Unable to work with comment: " + req.Comment.Body)
+		break
+	}
+}
+
+func parse(body string) *types.LabelAction {
+	labelAction := types.LabelAction{}
+	add := "Derek add label: "
+	remove := "Derek remove label: "
+
+	if len(body) > len(add) && body[0:len(add)] == add {
+		label := body[len(add):]
+		label = strings.Trim(label, " \t.,\n\r")
+		labelAction.Type = "AddLabel"
+		labelAction.Value = label
+	} else if len(body) > len(remove) && body[0:len(remove)] == remove {
+		label := body[len(remove):]
+		label = strings.Trim(label, " \t.,\n\r")
+		labelAction.Type = "RemoveLabel"
+		labelAction.Value = label
+	}
+	return &labelAction
+}
+
+func getMaintainers(owner string, repository string) []string {
+	client := http.Client{}
+	req, _ := http.NewRequest("GET", fmt.Sprintf("https://github.com/%s/%s/raw/master/MAINTAINERS", owner, repository), nil)
+
+	res, resErr := client.Do(req)
+	if resErr != nil {
+		log.Fatalln(resErr)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		log.Fatalln("HTTP Status code: %d while fetching maintainers list", res.StatusCode)
+	}
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	bytesOut, _ := ioutil.ReadAll(res.Body)
+	lines := string(bytesOut)
+	return strings.Split(lines, "\n")
+}
+
+func isMaintainer(userLogin string, repository types.Repository) bool {
+	maintainers := getMaintainers(repository.Owner.Login, repository.Name)
+	fmt.Println("UserLogin: "+userLogin+", Maintainers: ", maintainers)
+	allow := false
+	for _, maintainer := range maintainers {
+		if len(maintainer) > 0 && maintainer == userLogin {
+			allow = true
+			break
+		}
+	}
+
+	return allow
+}

--- a/handler.go
+++ b/handler.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-github/github"
 )
 
-func handle(req types.PullRequestOuter) {
+func handlePullRequest(req types.PullRequestOuter) {
 	ctx := context.Background()
 
 	token := os.Getenv("access_token")

--- a/types/types.go
+++ b/types/types.go
@@ -18,3 +18,32 @@ type PullRequestOuter struct {
 	PullRequest PullRequest `json:"pull_request"`
 	Action      string      `json:"action"`
 }
+
+type IssueCommentOuter struct {
+	Repository Repository `json:"repository"`
+	Comment    Comment    `json:"comment"`
+	Action     string     `json:"action"`
+	Issue      Issue      `json:"issue"`
+}
+
+type IssueLabel struct {
+	Name string `json:"name"`
+}
+
+type Issue struct {
+	Labels []IssueLabel `json:"labels"`
+	Number int          `json:"number"`
+}
+
+type Comment struct {
+	Body     string `json:"body"`
+	IssueURL string `json:"issue_url"`
+	User     struct {
+		Login string `json:"login"`
+	}
+}
+
+type LabelAction struct {
+	Type  string
+	Value string
+}


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

Allows non-write-access users to add labels to issues and PRs.

Here's an example:

`Derek add label: skill/intermediate`
`Derek remove label: skill/intermediate`

ACL is a plaintext file called MAINTAINERS in the root of the GitHub repo.

MAINTAINERS:
```
alexellis
johnmccabe
```
