### PR TITLE
Set the Github App ID via envvars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV cgi_headers="true"
 
 ENV fprocess="./derek"
 ENV secret_key="docker"
+ENV application=4385
 ENV installation=45362
 ENV private_key="derek.pem"
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ We have to build a Docker image with your .pem file included
 
 We'll also set the symmetric key or secret that you got from GitHub as the `secret_key` environmental variable. Validating via a symmetric key is also known as HMAC. If you want to turn this off (to edit and debug) then set `validate_hmac="false"`
 
-Fill out the `installation` variable with the installation ID you got from GitHub for Derek.
+Fill out the `application` variable with the ID of the registered Derek Github App, and the `installation` variable with the installation ID you got when adding Derek to your account.
 
 Set the following in your Dockerfile
 
 ```
 ENV secret_key="docker"
+ENV application=4385
 ENV installation=45362
 ENV private_key="derek.pem"
 

--- a/auth/client_factory.go
+++ b/auth/client_factory.go
@@ -19,8 +19,8 @@ type JwtAuth struct {
 }
 
 // MakeAccessTokenForInstallation makes an access token for an installation / private key
-func MakeAccessTokenForInstallation(installation string, privateKeyPath string) (string, error) {
-	signed, err := GetSignedJwtToken(privateKeyPath)
+func MakeAccessTokenForInstallation(appID, installation, privateKeyPath string) (string, error) {
+	signed, err := GetSignedJwtToken(appID, privateKeyPath)
 
 	if err == nil {
 		c := http.Client{}

--- a/auth/jwt_auth.go
+++ b/auth/jwt_auth.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GetSignedJwtToken get a tokens signed with private key
-func GetSignedJwtToken(keyPath string) (string, error) {
+func GetSignedJwtToken(appID, keyPath string) (string, error) {
 	if len(keyPath) == 0 {
 		return "", fmt.Errorf("unable to read from empty keypath, try setting env: \"private_key\" to a filename and path")
 	}
@@ -26,7 +26,7 @@ func GetSignedJwtToken(keyPath string) (string, error) {
 
 	now := time.Now()
 	claims := jwt.StandardClaims{
-		Issuer:    "4385",
+		Issuer:    appID,
 		IssuedAt:  now.Unix(),
 		ExpiresAt: now.Add(time.Minute * 9).Unix(),
 	}

--- a/commentHandler.go
+++ b/commentHandler.go
@@ -19,7 +19,7 @@ func makeClient() (*github.Client, context.Context) {
 
 	token := os.Getenv("access_token")
 	if len(token) == 0 {
-		newToken, tokenErr := auth.MakeAccessTokenForInstallation(os.Getenv("installation"), os.Getenv("private_key"))
+		newToken, tokenErr := auth.MakeAccessTokenForInstallation(os.Getenv("application"), os.Getenv("installation"), os.Getenv("private_key"))
 		if tokenErr != nil {
 			log.Fatalln(tokenErr.Error())
 		}

--- a/handler.go
+++ b/handler.go
@@ -18,7 +18,7 @@ func handlePullRequest(req types.PullRequestOuter) {
 
 	token := os.Getenv("access_token")
 	if len(token) == 0 {
-		newToken, tokenErr := auth.MakeAccessTokenForInstallation(os.Getenv("installation"), os.Getenv("private_key"))
+		newToken, tokenErr := auth.MakeAccessTokenForInstallation(os.Getenv("application"), os.Getenv("installation"), os.Getenv("private_key"))
 		if tokenErr != nil {
 			log.Fatalln(tokenErr.Error())
 		}


### PR DESCRIPTION
This PR sets the Derek Github Application ID via the `application`envvar. This ID is the one associated with the registered application, while the installation is associated the instance of Derek installed to your Github account.

Failing to set the correct id (ie the application ID) was causing the generation of JWT tokens to fail with an invalid permissions error, it had originally been hardcoded.

Have tested this here https://github.com/johnmccabe/webhook_test_delme/issues/1