### PR TITLE
Add assign and unassign commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,19 @@ It's derek ![](https://avatars2.githubusercontent.com/in/4385?v=4&u=55bb4ce98267
 
 When someone sends a PR without a sign-off, I'll apply a label `no-dco` and also send them a comment pointing them to the contributor guide. Most of the time when I've been helping the OpenFaaS project - people read my message and fix things up without you having to get involved.
 
-* Allow users in a specified MAINTAINERS file to apply comments to issues
+* Allow users in a specified MAINTAINERS file to apply labels/assign users to issues
 
 You don't have to give people full write access anymore to help you manage issues. I'll do that for you, just put them in a MAINTAINERS file in the root and when they comment on an issue then I'll use my granular permissions instead.
+
+> Note that the assign/unassign commands provides the shortcut `me` to assign to the commenter
 
 Example:
 
 ```
 Derek add label: awesome
+Derek remove label: awesome
+Derek assign: alexellis
+Derek unassign: me
 ```
 
 [Live demo here](https://twitter.com/alexellisuk/status/905694832445804544)

--- a/commentHandler.go
+++ b/commentHandler.go
@@ -127,32 +127,24 @@ func handleComment(req types.IssueCommentOuter) {
 
 func parse(body string) *types.CommentAction {
 	commentAction := types.CommentAction{}
-	add := "Derek add label: "
-	remove := "Derek remove label: "
-	assign := "Derek assign: "
-	unassign := "Derek unassign: "
 
-	if len(body) > len(add) && body[0:len(add)] == add {
-		label := body[len(add):]
-		label = strings.Trim(label, " \t.,\n\r")
-		commentAction.Type = "AddLabel"
-		commentAction.Value = label
-	} else if len(body) > len(remove) && body[0:len(remove)] == remove {
-		label := body[len(remove):]
-		label = strings.Trim(label, " \t.,\n\r")
-		commentAction.Type = "RemoveLabel"
-		commentAction.Value = label
-	} else if len(body) > len(assign) && body[0:len(assign)] == assign {
-		assignee := body[len(assign):]
-		assignee = strings.Trim(assignee, " \t.,\n\r")
-		commentAction.Type = "Assign"
-		commentAction.Value = assignee
-	} else if len(body) > len(unassign) && body[0:len(unassign)] == unassign {
-		assignee := body[len(unassign):]
-		assignee = strings.Trim(assignee, " \t.,\n\r")
-		commentAction.Type = "Unassign"
-		commentAction.Value = assignee
+	commands := map[string]string{
+		"Derek add label: ":    "AddLabel",
+		"Derek remove label: ": "RemoveLabel",
+		"Derek assign: ":       "Assign",
+		"Derek unassign: ":     "Unassign",
 	}
+
+	for trigger, commandType := range commands {
+		if len(body) > len(trigger) && body[0:len(trigger)] == trigger {
+			val := body[len(trigger):]
+			val = strings.Trim(val, " \t.,\n\r")
+			commentAction.Type = commandType
+			commentAction.Value = val
+			break
+		}
+	}
+
 	return &commentAction
 }
 

--- a/commentHandler.go
+++ b/commentHandler.go
@@ -96,7 +96,11 @@ func handleComment(req types.IssueCommentOuter) {
 
 		if allowed {
 			client, ctx := makeClient()
-			_, _, err := client.Issues.AddAssignees(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, []string{command.Value})
+			assignee := command.Value
+			if assignee == "me" {
+				assignee = req.Comment.User.Login
+			}
+			_, _, err := client.Issues.AddAssignees(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, []string{assignee})
 			if err != nil {
 				log.Fatalln(err)
 			}
@@ -110,7 +114,11 @@ func handleComment(req types.IssueCommentOuter) {
 
 		if allowed {
 			client, ctx := makeClient()
-			_, _, err := client.Issues.RemoveAssignees(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, []string{command.Value})
+			assignee := command.Value
+			if assignee == "me" {
+				assignee = req.Comment.User.Login
+			}
+			_, _, err := client.Issues.RemoveAssignees(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, []string{assignee})
 			if err != nil {
 				log.Fatalln(err)
 			}

--- a/types/types.go
+++ b/types/types.go
@@ -43,7 +43,7 @@ type Comment struct {
 	}
 }
 
-type LabelAction struct {
+type CommentAction struct {
 	Type  string
 	Value string
 }


### PR DESCRIPTION
This PR adds commands for assigning and unassigning issues/PRs. For example:
```
Derek assign: johnmccabe
Derek unassign: johnmccabe
```
It also provides the shortcut `me` to assign/unassign the user making the comment:
```
Derek assign: me
Derek unassign: me
```
Note that the README has been updated, and the `parse()` function refactored.

This has been tested here - https://github.com/johnmccabe/webhook_test_delme/pull/2