### PR TITLE
Replacing MAINTAINERS with .DEREK.yml for more granular permissions

### DIFF
--- a/.DEREK.yml
+++ b/.DEREK.yml
@@ -1,0 +1,7 @@
+maintainers:
+ - alexellis
+ - rgee0
+ - johnmccabe
+features:
+ - dco_check
+ - comments

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,1 +1,0 @@
-alexellis


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

Migrating to MAINTAINERS to the new model.  Not sure if Derek is gainfully employed on this repo yet but the changes enable anyone forking the repo to more readily understand how to configure this part of the application.

Also added rgee0 and johnmccabe to the maintainers list to be consistent with README.md