### PR TITLE
Set title / double action bug / pullRequest tests / lock issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM golang:1.9.2-alpine as build
 RUN mkdir -p /go/src/github.com/alexellis/derek
 WORKDIR /go/src/github.com/alexellis/derek
 COPY	.	.
+
+RUN go test $(go list ./...) -cover
+
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o derek .
 
 FROM alpine:3.6

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ We are planning to add roles in the ROADMAP which will mean you can get even mor
 
 Example:
 
+* Titles
+
+```
+Derek set title: This is a more meaningful title
+```
+
 * Labels
 
 ```
@@ -64,14 +70,18 @@ Derek unassign: me
 
 ```
 Derek close
-Derek reopen 
+Derek reopen
+Derek lock
+Derek unlock
 ```
 
 Coming soon
 * [x] Derek as a managed GitHub App
-* [ ] Lock thread
-* [ ] Edit title
+* [x] Lock thread
+* [x] Edit title
 * [x] Toggle the DCO-feature
+* [ ] Add roles & actions
+* [ ] Branch Checking
 
 [Live demo here](https://twitter.com/alexellisuk/status/905694832445804544)
 

--- a/commentHandler_test.go
+++ b/commentHandler_test.go
@@ -146,3 +146,99 @@ func Test_Parsing_Assignments(t *testing.T) {
 		})
 	}
 }
+
+func Test_Parsing_Titles(t *testing.T) {
+
+	var titleOptions = []struct {
+		title        string
+		body         string
+		expectedType string
+		expectedVal  string
+	}{
+		{
+			title:        "Set Title",
+			body:         "Derek set title: This is a really great Title!",
+			expectedType: "SetTitle",
+			expectedVal:  "This is a really great Title!",
+		},
+		{
+			title:        "Mis-spelling of title",
+			body:         "Derek set titel: This is a really great Title!",
+			expectedType: "",
+			expectedVal:  "",
+		},
+		{
+			title:        "Empty Title",
+			body:         "Derek set title: ",
+			expectedType: "", //blank because it should fail isValidCommand
+			expectedVal:  "",
+		},
+		{
+			title:        "Empty Title (Double Space)",
+			body:         "Derek set title:  ",
+			expectedType: "SetTitle",
+			expectedVal:  "",
+		},
+	}
+
+	for _, test := range titleOptions {
+		t.Run(test.title, func(t *testing.T) {
+
+			action := parse(test.body)
+			if action.Type != test.expectedType || action.Value != test.expectedVal {
+				t.Errorf("\nAction - wanted: %s, got %s\nValue - wanted: %s, got %s", test.expectedType, action.Type, test.expectedVal, action.Value)
+			}
+		})
+	}
+}
+
+func Test_assessState(t *testing.T) {
+
+	var stateOptions = []struct {
+		title            string
+		requestedAction  string
+		currentState     string
+		expectedNewState string
+		expectedBool     bool
+	}{
+		{
+			title:            "Currently Closed and trying to close",
+			requestedAction:  "close",
+			currentState:     "closed",
+			expectedNewState: "",
+			expectedBool:     false,
+		},
+		{
+			title:            "Currently Open and trying to reopen",
+			requestedAction:  "reopen",
+			currentState:     "open",
+			expectedNewState: "",
+			expectedBool:     false,
+		},
+		{
+			title:            "Currently Closed and trying to open",
+			requestedAction:  "reopen",
+			currentState:     "closed",
+			expectedNewState: "open",
+			expectedBool:     true,
+		},
+		{
+			title:            "Currently Open and trying to close",
+			requestedAction:  "close",
+			currentState:     "open",
+			expectedNewState: "closed",
+			expectedBool:     true,
+		},
+	}
+
+	for _, test := range stateOptions {
+		t.Run(test.title, func(t *testing.T) {
+
+			newState, validTransition := checkTransition(test.requestedAction, test.currentState)
+
+			if newState != test.expectedNewState || validTransition != test.expectedBool {
+				t.Errorf("\nStates - wanted: %s, got %s\nValidity - wanted: %t, got %t\n", test.expectedNewState, newState, test.expectedBool, validTransition)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 const dcoCheck = "dco_check"
 const comments = "comments"
+const deleted = "deleted"
 
 func hmacValidation() bool {
 	val := os.Getenv("validate_hmac")
@@ -66,9 +67,10 @@ func handleEvent(eventType string, bytesIn []byte) error {
 		if err != nil {
 			return fmt.Errorf("Unable to access maintainers file at: %s/%s", req.Repository.Owner.Login, req.Repository.Name)
 		}
-
-		if enabledFeature(dcoCheck, derekConfig) {
-			handlePullRequest(req)
+		if req.Action != closed {
+			if enabledFeature(dcoCheck, derekConfig) {
+				handlePullRequest(req)
+			}
 		}
 		break
 
@@ -90,8 +92,10 @@ func handleEvent(eventType string, bytesIn []byte) error {
 			return fmt.Errorf("Unable to access maintainers file at: %s/%s", req.Repository.Owner.Login, req.Repository.Name)
 		}
 
-		if permittedUserFeature(comments, derekConfig, req.Comment.User.Login) {
-			handleComment(req)
+		if req.Action != deleted {
+			if permittedUserFeature(comments, derekConfig, req.Comment.User.Login) {
+				handleComment(req)
+			}
 		}
 		break
 	default:

--- a/pullRequestHandler.go
+++ b/pullRequestHandler.go
@@ -8,9 +8,9 @@ import (
 	"os"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/google/go-github/github"
 	"github.com/alexellis/derek/auth"
 	"github.com/alexellis/derek/types"
+	"github.com/google/go-github/github"
 )
 
 func handlePullRequest(req types.PullRequestOuter) {

--- a/pullRequestHandler_test.go
+++ b/pullRequestHandler_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-github/github"
+)
+
+func Test_isSigned(t *testing.T) {
+
+	var signOffOpts = []struct {
+		title        string
+		message      string
+		expectedBool bool
+	}{
+		{
+			title:        "Correctly signed off full string",
+			message:      "Signed-off-by:",
+			expectedBool: true,
+		},
+		{
+			title:        "Correctly signed off within string",
+			message:      "This PR was Signed-off-by: rgee0",
+			expectedBool: true,
+		},
+		{
+			title:        "Not hypenated signed off within string",
+			message:      "This PR was Signed off by: rgee0",
+			expectedBool: false,
+		},
+		{
+			title:        "Not hypenated signed full string",
+			message:      "Signed off by:",
+			expectedBool: false,
+		},
+	}
+	for _, test := range signOffOpts {
+		t.Run(test.title, func(t *testing.T) {
+
+			containsSignoff := isSigned(test.message)
+
+			if containsSignoff != test.expectedBool {
+				t.Errorf("Is signed off - Testing '%s'  - wanted: %t, found %t", test.message, test.expectedBool, containsSignoff)
+			}
+		})
+	}
+}
+
+func Test_hasNoDcoLabel(t *testing.T) {
+
+	var labelOpts = []struct {
+		title        string
+		labels       []string
+		expectedBool bool
+	}{
+		{
+			title:        "Has the no-dco label",
+			labels:       []string{"no-dco"},
+			expectedBool: true,
+		},
+		{
+			title:        "Doesnt have the no-dco label",
+			labels:       []string{"proposal", "bug", "question"},
+			expectedBool: false,
+		},
+		{
+			title:        "Has the no-dco label amongst others",
+			labels:       []string{"proposal", "bug", "question", "no-dco"},
+			expectedBool: true,
+		},
+		{
+			title:        "Has no labels",
+			labels:       []string{},
+			expectedBool: false,
+		},
+	}
+	for _, test := range labelOpts {
+		t.Run(test.title, func(t *testing.T) {
+
+			var ghLabels []github.Label
+			for _, label := range test.labels {
+				ghLabels = append(ghLabels, github.Label{Name: &label})
+			}
+
+			inputIssue := &github.Issue{Labels: ghLabels}
+
+			hasLabel := hasNoDcoLabel(inputIssue)
+
+			if hasLabel != test.expectedBool {
+				t.Errorf("Has no-dco label - wanted: %t, found %t", test.expectedBool, hasLabel)
+			}
+		})
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -44,6 +44,9 @@ type IssueLabel struct {
 type Issue struct {
 	Labels []IssueLabel `json:"labels"`
 	Number int          `json:"number"`
+	Title  string       `json:"title"`
+	Locked bool         `json:"locked"`
+	State  string       `json:"state"`
 }
 
 type Comment struct {


### PR DESCRIPTION
Fixes #21 
Fixes #24 
Fixes #15 
Fixes #28

Summary of changes:

* Added `go test` to Dockerfile.
* Added a check that the issue_comment webhook action isn't `deleted` before taking action, as this was causing Derek to re-trigger when comments originally aimed at Derek deleted.
* Added a check that the pull_request webhook action isn't `closed` before taking action, as this was causing Derek to perform the dco_check unnecessarily.
* Added tests to cover some of the pullRequestHander methods.
* Implemented `Derek set title:`, `Derek lock` & `Derek unlock` commands
* Updated `README.md` to cover new features, marking the lock & title features as complete and adding two additional features.
* Extracted a method in the open/close switch clause to assess requested state against current state and return whether the requested transition is valid.  Added a test for this.
* Added checking to `setTitle`, `close`, `reopen`, `lock` & `unlock` so that API calls are only made when necessary hence minimizing the effect on API rate limits.
* Broadened the scope of the `Issue` type to enable capturing details required for evaluating whether requests to the API are necessary.

Currently deployed at [rgee0/Test](https://github.com/rgee0/Test) for evaluation.

n.b. The github comparison views  aren't displaying the changes at all well.  It doesn't seem to be lining the line numbers up correctly.