### PR TITLE
Add "curators" alias to .DEREK.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,21 @@ You don't have to give people full write access anymore to help you manage issue
 
 * Wait.. doesn't the term "maintainer" mean write access in GitHub?
 
-No - the GitHub UI doesn't use the term maintainer, it speaks of collaborators or team members with write access. Adding someone to a file called maintainers means they have opted to help you maintain the code by helpng curate, triage and chase up issues and PRs. Derek means you no longer have to grant full write-access to let people help you maintain the project.
+No this is what Derek sets out to resolve. The users in your maintainers list have granular permissions which you'll see in detail when you add the app to your repo org.
+
+```
+maintainers:
+- alexellis
+- rgee0
+```
+
+You can use the alias "curators" instead for the exact same behaviour:
+
+```
+curators:
+- alexellis
+- rgee0
+```
 
 * What about roles?
 

--- a/permissionsHandler.go
+++ b/permissionsHandler.go
@@ -69,10 +69,20 @@ func getConfig(owner string, repository string) (*types.DerekConfig, error) {
 	bytesOut, _ := ioutil.ReadAll(res.Body)
 	var config types.DerekConfig
 
-	err := yaml.Unmarshal(bytesOut, &config)
+	err := parseConfig(bytesOut, &config)
 	if err != nil {
 		return nil, err
 	}
 
 	return &config, nil
+}
+
+func parseConfig(bytesOut []byte, config *types.DerekConfig) error {
+	err := yaml.Unmarshal(bytesOut, &config)
+
+	if len(config.Maintainers) == 0 && len(config.Curators) > 0 {
+		config.Maintainers = config.Curators
+	}
+
+	return err
 }

--- a/permissionsHandler_test.go
+++ b/permissionsHandler_test.go
@@ -6,6 +6,30 @@ import (
 	"github.com/alexellis/derek/types"
 )
 
+func Test_maintainersparsed(t *testing.T) {
+	config := types.DerekConfig{}
+	parseConfig([]byte(`maintainers:
+- alexellis
+- rgee0
+`), &config)
+	actual := len(config.Maintainers)
+	if actual != 2 {
+		t.Errorf("want: %d maintainers, got: %d", 2, actual)
+	}
+}
+
+func Test_curatorequalsmaintainer(t *testing.T) {
+	config := types.DerekConfig{}
+	parseConfig([]byte(`curators:
+- alexellis
+- rgee0
+`), &config)
+	actual := len(config.Maintainers)
+	if actual != 2 {
+		t.Errorf("want: %d maintainers, got: %d", 2, actual)
+	}
+}
+
 func Test_enabledFeature(t *testing.T) {
 
 	var enableFeatureOpts = []struct {

--- a/types/types.go
+++ b/types/types.go
@@ -60,7 +60,13 @@ type CommentAction struct {
 }
 
 type DerekConfig struct {
-	Features    []string
+
+	// Features can be turned on/off if needed.
+	Features []string
+
+	// Users who are enrolled to make use of Derek
 	Maintainers []string
-	Curators    []string
+
+	// Curators is an alias for Maintainers and is only used if the Maintainers list is empty.
+	Curators []string
 }

--- a/types/types.go
+++ b/types/types.go
@@ -62,4 +62,5 @@ type CommentAction struct {
 type DerekConfig struct {
 	Features    []string
 	Maintainers []string
+	Curators    []string
 }


### PR DESCRIPTION
This change adds "curators" as an alias to "maintainers" in the .DEREK.yml file.

Some users were finding the term confusing due to existing use of the term maintainers within their project. When we get to roles in Derek 2.0 that will go away, but for now this should make Derek easier to understand/install. 