### PR TITLE
Add commit message linting feature

### DIFF
--- a/GET.md
+++ b/GET.md
@@ -49,7 +49,19 @@ maintainers:
 features:
  - dco_check
  - comments
+ - commit_linting
 ```
+
+Features:
+
+* `dco_check` - checks that each commit finishes with a "Signed-off-by:" statement
+* `comments` - allows `maintainers` to issue commands to Derek to add labels etc
+* `commit_linting` - applies linting rules to commit messages
+
+Commit linting ensures:
+
+* subjects start with a capital letter
+* subject lines are less than 50 characters
 
 **Testing**
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Derek unlock
 * [x] Lock thread
 * [x] Edit title
 * [x] Toggle the DCO-feature
+* [x] Add commit message linting feature
 
 Future work:
 

--- a/main.go
+++ b/main.go
@@ -11,14 +11,7 @@ import (
 	"github.com/alexellis/derek/types"
 )
 
-const dcoCheck = "dco_check"
-const comments = "comments"
 const deleted = "deleted"
-
-func hmacValidation() bool {
-	val := os.Getenv("validate_hmac")
-	return len(val) > 0 && (val == "1" || val == "true")
-}
 
 func main() {
 	bytesIn, _ := ioutil.ReadAll(os.Stdin)
@@ -53,7 +46,7 @@ func handleEvent(eventType string, bytesIn []byte) error {
 	case "pull_request":
 		req := types.PullRequestOuter{}
 		if err := json.Unmarshal(bytesIn, &req); err != nil {
-			return fmt.Errorf("Cannot parse input %s", err.Error())
+			return fmt.Errorf("pull_request handler, cannot parse input: %s", err.Error())
 		}
 
 		customer, err := auth.IsCustomer(req.Repository)
@@ -67,11 +60,18 @@ func handleEvent(eventType string, bytesIn []byte) error {
 		if err != nil {
 			return fmt.Errorf("Unable to access maintainers file at: %s/%s", req.Repository.Owner.Login, req.Repository.Name)
 		}
+
 		if req.Action != closedConstant {
-			if enabledFeature(dcoCheck, derekConfig) {
-				handlePullRequest(req)
+			prFeatures := types.PullRequestFeatures{
+				CommitLintingFeature: enabledFeature(types.CommitLintingFeature, derekConfig),
+				DCOCheckFeature:      enabledFeature(types.DCOCheckFeature, derekConfig),
+			}
+
+			if prFeatures.Enabled() {
+				handlePullRequest(req, prFeatures)
 			}
 		}
+
 		break
 
 	case "issue_comment":
@@ -93,14 +93,21 @@ func handleEvent(eventType string, bytesIn []byte) error {
 		}
 
 		if req.Action != deleted {
-			if permittedUserFeature(comments, derekConfig, req.Comment.User.Login) {
+			if permittedUserFeature(types.CommentFeature, derekConfig, req.Comment.User.Login) {
 				handleComment(req)
 			}
 		}
+
 		break
+
 	default:
 		return fmt.Errorf("X_Github_Event want: ['pull_request', 'issue_comment'], got: " + eventType)
 	}
 
 	return nil
+}
+
+func hmacValidation() bool {
+	val := os.Getenv("validate_hmac")
+	return len(val) > 0 && (val == "1" || val == "true")
 }

--- a/pullRequestHandler.go
+++ b/pullRequestHandler.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-github/github"
 )
 
-func handlePullRequest(req types.PullRequestOuter) {
+func handlePullRequest(req types.PullRequestOuter, prFeatures types.PullRequestFeatures) {
 	ctx := context.Background()
 
 	token := os.Getenv("access_token")
@@ -32,88 +32,98 @@ func handlePullRequest(req types.PullRequestOuter) {
 
 	client := auth.MakeClient(ctx, token)
 
-	hasUnsignedCommits, err := hasUnsigned(req, client)
+	commits, commitFetchErr := getCommits(req, client)
 
-	if err != nil {
-		log.Fatal(err)
-	} else if hasUnsignedCommits {
-		fmt.Println("May need to apply labels on item.")
+	if commitFetchErr != nil {
+		log.Fatal(commitFetchErr)
+	}
 
-		issue, _, labelErr := client.Issues.Get(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number)
+	issue, _, labelErr := client.Issues.Get(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number)
+	if labelErr != nil {
+		log.Fatalln("Unable to fetch labels for PR %s/%s/#%d", req.Repository.Owner, req.Repository.Name, req.PullRequest.Number)
+	}
 
-		if labelErr != nil {
-			log.Fatalln(labelErr)
+	if prFeatures.CommitLintingFeature {
+		lintResult := lintCommits(commits)
+		applyErr := applyLintingLabel(req, client, issue, lintResult)
+		if applyErr != nil {
+			log.Printf("Error applying linting rule: %s", applyErr)
 		}
-		fmt.Println("Current labels ", issue.Labels)
+	}
 
-		if hasNoDcoLabel(issue) == false {
-			fmt.Println("Applying label")
-			_, res, assignLabelErr := client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, []string{"no-dco"})
-			if assignLabelErr != nil {
-				log.Fatalf("%s limit: %d, remaining: %d", assignLabelErr, res.Limit, res.Remaining)
-			}
+	if prFeatures.DCOCheckFeature {
+		if hasUnsigned(commits) == true {
+			fmt.Println("May need to apply labels on item.")
 
-			link := fmt.Sprintf("https://github.com/%s/%s/blob/master/CONTRIBUTING.md", req.Repository.Owner.Login, req.Repository.Name)
-			body := `Thank you for your contribution. I've just checked and your commit doesn't appear to be signed-off.
+			fmt.Println("Current labels ", issue.Labels)
+
+			if hasLabelAssigned("no-dco", issue) == false {
+				fmt.Println("Applying label")
+				_, res, assignLabelErr := client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, []string{"no-dco"})
+				if assignLabelErr != nil {
+					log.Fatalf("%s limit: %d, remaining: %d", assignLabelErr, res.Limit, res.Remaining)
+				}
+
+				link := fmt.Sprintf("https://github.com/%s/%s/blob/master/CONTRIBUTING.md", req.Repository.Owner.Login, req.Repository.Name)
+				body := `Thank you for your contribution. I've just checked and your commit doesn't appear to be signed-off.
 That's something we need before your Pull Request can be merged. Please see our [contributing guide](` + link + `).`
 
-			comment := &github.IssueComment{
-				Body: &body,
+				comment := &github.IssueComment{
+					Body: &body,
+				}
+
+				comment, resp, err := client.Issues.CreateComment(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, comment)
+				if err != nil {
+					log.Fatalf("%s limit: %d, remaining: %d", assignLabelErr, resp.Limit, resp.Remaining)
+					log.Fatal(err)
+				}
+				fmt.Println(comment, resp.Rate)
 			}
+		} else {
+			fmt.Println("Things look OK right now.")
 
-			comment, resp, err := client.Issues.CreateComment(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, comment)
-			if err != nil {
-				log.Fatalf("%s limit: %d, remaining: %d", assignLabelErr, resp.Limit, resp.Remaining)
-				log.Fatal(err)
-			}
-			fmt.Println(comment, resp.Rate)
-		}
-	} else {
-		fmt.Println("Things look OK right now.")
-		issue, res, labelErr := client.Issues.Get(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number)
-
-		if labelErr != nil {
-			log.Fatalf("%s limit: %d, remaining: %d", labelErr, res.Limit, res.Remaining)
-			log.Fatalln()
-		}
-
-		if hasNoDcoLabel(issue) {
-			fmt.Println("Removing label")
-			_, removeLabelErr := client.Issues.RemoveLabelForIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, "no-dco")
-			if removeLabelErr != nil {
-				log.Fatal(removeLabelErr)
+			if hasLabelAssigned("no-dco", issue) {
+				fmt.Println("Removing label")
+				_, removeLabelErr := client.Issues.RemoveLabelForIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, "no-dco")
+				if removeLabelErr != nil {
+					log.Fatal(removeLabelErr)
+				}
 			}
 		}
 	}
 }
 
-func hasNoDcoLabel(issue *github.Issue) bool {
+func hasLabelAssigned(labelName string, issue *github.Issue) bool {
 	if issue != nil {
 		for _, label := range issue.Labels {
-			if label.GetName() == "no-dco" {
+			if label.GetName() == labelName {
 				return true
 			}
 		}
 	}
+
 	return false
 }
 
-func hasUnsigned(req types.PullRequestOuter, client *github.Client) (bool, error) {
-	hasUnsigned := false
+func getCommits(req types.PullRequestOuter, client *github.Client) ([]*github.RepositoryCommit, error) {
 	ctx := context.Background()
 
-	var err error
+	var responseErr error
 	listOpts := &github.ListOptions{
 		Page: 0,
 	}
 
 	commits, resp, err := client.PullRequests.ListCommits(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, listOpts)
 	if err != nil {
-		log.Fatalf("Error getting PR %d\n%s", req.PullRequest.Number, err.Error())
-		return hasUnsigned, err
+		responseErr = fmt.Errorf("unable to fetch commits for PR: %d, Error: %s", req.PullRequest.Number, err.Error())
 	}
 
-	fmt.Println("Rate limiting", resp.Rate)
+	log.Printf("Rate limiting remaining: %d", resp.Rate.Remaining)
+	return commits, responseErr
+}
+
+func hasUnsigned(commits []*github.RepositoryCommit) bool {
+	hasUnsigned := false
 
 	for _, commit := range commits {
 		if commit.Commit != nil && commit.Commit.Message != nil {
@@ -123,9 +133,97 @@ func hasUnsigned(req types.PullRequestOuter, client *github.Client) (bool, error
 		}
 	}
 
-	return hasUnsigned, err
+	return hasUnsigned
 }
 
 func isSigned(msg string) bool {
 	return strings.Contains(msg, "Signed-off-by:")
+}
+
+func lintCommits(commits []*github.RepositoryCommit) bool {
+	for _, commit := range commits {
+		if commit.Commit != nil && commit.Commit.Message != nil {
+			if lintCommit(commit.Commit.Message) == false {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func lintCommit(message *string) bool {
+	var valid bool
+
+	if message == nil {
+		return false
+	}
+
+	parts := strings.Split(*message, "\n")
+
+	if len(parts) > 0 {
+		lengthValid := len(parts[0]) <= 50
+		var startsWithUpper bool
+
+		firstCharacter := getFirstCharacter(parts[0])
+		if firstCharacter != nil {
+			startsWithUpper = len(*firstCharacter) > 0 && strings.ToUpper(*firstCharacter) == *firstCharacter
+		}
+
+		valid = lengthValid && startsWithUpper
+	}
+
+	return valid
+}
+
+func getFirstCharacter(msg string) *string {
+	var ret *string
+
+	for _, runeVal := range msg {
+		asStr := string(runeVal)
+		ret = &asStr
+		break
+	}
+
+	return ret
+}
+
+func applyLintingLabel(req types.PullRequestOuter, client *github.Client, issue *github.Issue, lintResult bool) error {
+	labelCaption := "review/commit-message"
+	var actionErr error
+	hasLabel := hasLabelAssigned(labelCaption, issue)
+
+	ctx := context.Background()
+
+	if hasLabel {
+		if lintResult == true {
+			res, assignLabelErr := client.Issues.RemoveLabelForIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, labelCaption)
+			if assignLabelErr != nil {
+				actionErr = fmt.Errorf("removeLabel: %s limit: %d, remaining: %d", assignLabelErr, res.Limit, res.Remaining)
+			}
+		}
+	} else {
+		if lintResult == false {
+			_, res, assignLabelErr := client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, []string{labelCaption})
+			if assignLabelErr != nil {
+				actionErr = fmt.Errorf("addLabel: %s limit: %d, remaining: %d", assignLabelErr, res.Limit, res.Remaining)
+			}
+			link := fmt.Sprintf("https://github.com/%s/%s/blob/master/CONTRIBUTING.md", req.Repository.Owner.Login, req.Repository.Name)
+
+			body := `Please check that your commit messages fit within [these guidelines](` + link + `):
+- Commit subject should not exceed 50 characters
+- Commit subject should start with an uppercase letter
+`
+
+			comment := &github.IssueComment{
+				Body: &body,
+			}
+
+			_, _, err := client.Issues.CreateComment(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, comment)
+			if err != nil {
+				actionErr = fmt.Errorf("unable to create comment due to linting check: %s", err)
+			}
+		}
+	}
+
+	return actionErr
 }

--- a/pullRequestHandler_test.go
+++ b/pullRequestHandler_test.go
@@ -6,6 +6,43 @@ import (
 	"github.com/google/go-github/github"
 )
 
+func Test_LintingResultGiven_WithLongSubject(t *testing.T) {
+
+	var testCases = []struct {
+		scenario   string
+		message    string
+		lintResult bool
+	}{
+		{
+			scenario:   "Commit subject over 50 chars",
+			message:    "This commit is necessary to make sure that all future commits conform to a certain set pattern\nSigned-off-by: Alex Ellis <alex@openfaas.com>",
+			lintResult: false,
+		},
+		{
+			scenario:   "Commit subject exactly 50 chars",
+			message:    "This commit subject falls well within the boundar\nSigned-off-by: Alex Ellis <alex@openfaas.com>",
+			lintResult: true,
+		},
+		{
+			scenario:   "Commit subject starts with lowercase",
+			message:    "has lowercase subject\nSigned-off-by: Alex Ellis <alex@openfaas.com>",
+			lintResult: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+
+		testMsg := testCase.message
+		result := lintCommit(&testMsg)
+
+		if result != testCase.lintResult {
+			t.Logf("scenario: %s - want linting: %v, but got: %v\n  message: %s", testCase.scenario, testCase.lintResult, result, testCase.message)
+			t.Fail()
+		}
+	}
+
+}
+
 func Test_isSigned(t *testing.T) {
 
 	var signOffOpts = []struct {
@@ -84,7 +121,7 @@ func Test_hasNoDcoLabel(t *testing.T) {
 
 			inputIssue := &github.Issue{Labels: ghLabels}
 
-			hasLabel := hasNoDcoLabel(inputIssue)
+			hasLabel := hasLabelAssigned("no-dco", inputIssue)
 
 			if hasLabel != test.expectedBool {
 				t.Errorf("Has no-dco label - wanted: %t, found %t", test.expectedBool, hasLabel)

--- a/types/features.go
+++ b/types/features.go
@@ -1,0 +1,15 @@
+package types
+
+const DCOCheckFeature = "dco_check"
+const CommitLintingFeature = "commit_linting"
+const CommentFeature = "comments"
+
+// PullRequestFeatures
+type PullRequestFeatures struct {
+	DCOCheckFeature      bool
+	CommitLintingFeature bool
+}
+
+func (p *PullRequestFeatures) Enabled() bool {
+	return p.DCOCheckFeature || p.CommitLintingFeature
+}


### PR DESCRIPTION
Adds feature to .DEREK.yml `commit_linting`, which when enabled
lints commit messages with a style consistent with the guidelines
written up by Chris Beams [1]. The linting will place a label on a PR
and send a comment when it fails linting, but this is not blocking.

The label used is: review/commit-message and that will be removed
if and when the linting is fixed.

Unit test coverage is added for the linting.

The DCO checking feature was also tested and an optimization was
added so that the PR labels are only fetched once and then re-used
this is to save on API rate-limiting and server trips.

[1] https://chris.beams.io/posts/git-commit/

Signed-off-by: Alex Ellis <alexellis2@gmail.com>