### PR TITLE
Add secret support for private_key and secret_key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ auth/*.pem
 template
 build
 secrets.yml
+derek_*_key

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ auth/*.pem
 template
 build
 secrets.yml
-derek_*_key
+derek-*-key

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,12 @@ FROM alpine:3.6
 
 RUN apk --no-cache add curl ca-certificates \ 
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSL https://github.com/alexellis/faas/releases/download/0.6.11/fwatchdog > /usr/bin/fwatchdog \
+    && curl -sSL https://github.com/alexellis/faas/releases/download/0.7.7/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 
 WORKDIR /root/
 COPY --from=build /go/src/github.com/alexellis/derek/derek derek
-
-# Replace this with a Swarm secret, so that the image can be pushed remotely.
-#COPY derek.pem	.
 
 ENV cgi_headers="true"
 ENV validate_hmac="true"

--- a/GET.md
+++ b/GET.md
@@ -28,7 +28,7 @@ $ docker build -t derek .
 
 ### Configure stack.yml:
 
-This is where Derek finds the details he needs to do the work he does.  The main areas that will need to be updated are the installation and application variables.  The gateway value may also need amending if the gateway is remote.
+This is where Derek finds the details he needs to do the work he does.  The main area that will need to be updated is the application variable.  The gateway value may also need amending if the gateway is remote.
 
 ``` yml
 provider:
@@ -41,7 +41,6 @@ functions:
     image: derek
     lang: Dockerfile
   environment:
-    installation: <your_GH_installationID>
     application: <your_GH_applicationID>
     validate_hmac: true
     debug: true
@@ -49,7 +48,7 @@ functions:
     - derek-secret-key
     - derek-private-key
 ```
-Fill out the `application` variable with the ID of the registered Derek GitHub App, and the `installation` variable with the installation ID received when adding Derek to your account.
+Fill out the `application` variable with the ID of the registered Derek GitHub App.
 
 Validating via a symmetric key is also known as HMAC. If the webhook secret wasn't set earlier and you want to turn this off (to edit and debug) then set `validate_hmac="false"`
 

--- a/GET.md
+++ b/GET.md
@@ -12,11 +12,23 @@ Read on if you want to setup your own cluster, OpenFaaS and a private GitHub App
 
 * Install Derek as a GitHub app and get your private key, save it as "derek.pem".
 
-* It is also recommended that you set a webhook secret within the GitHub application settings.
+* It is also recommended that you set a webhook secret within the GitHub application settings. If applying secrets from files, store this in a file called "derek-secret-key".
 
 ### Add your secrets :
   
-Using the method appropriate to the orchestrator chosen during the OpenFaaS setup add `derek.pem` and the GitHub webhook secret as `derek_private_key` and `derek_secret_key` respectively.
+Using the method appropriate to the orchestrator chosen during the OpenFaaS setup add `derek.pem` and the GitHub webhook secret as `derek-private-key` and `derek-secret-key` respectively.
+
+Using Docker with files:
+```
+$ docker secret create derek-private-key derek.pem && \
+    docker secret create derek-secret-key derek-secret-key
+```
+
+Using Kubernetes:
+```
+$ kubectl create secret generic derek-private-key --from-file=path/to/derek.pem && \
+    kubectl create secret generic derek-secret-key --from-file=path/to/derek-secret-key
+```
 
 ### Configure Docker image:
 

--- a/auth/client_factory.go
+++ b/auth/client_factory.go
@@ -19,8 +19,8 @@ type JwtAuth struct {
 }
 
 // MakeAccessTokenForInstallation makes an access token for an installation / private key
-func MakeAccessTokenForInstallation(appID string, installation int, privateKeyPath string) (string, error) {
-	signed, err := GetSignedJwtToken(appID, privateKeyPath)
+func MakeAccessTokenForInstallation(appID string, installation int) (string, error) {
+	signed, err := GetSignedJwtToken(appID)
 
 	if err == nil {
 		c := http.Client{}

--- a/auth/hmac.go
+++ b/auth/hmac.go
@@ -1,11 +1,15 @@
 package auth
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
 )
+
+const derekSecretKey = "/run/secrets/derek-secret-key"
 
 // CheckMAC verifies hash checksum
 func CheckMAC(message, messageMAC, key []byte) bool {
@@ -17,14 +21,23 @@ func CheckMAC(message, messageMAC, key []byte) bool {
 }
 
 // ValidateHMAC validate a digest from Github via xHubSignature
-func ValidateHMAC(bytesIn []byte, xHubSignature string, secretKey string) error {
+func ValidateHMAC(bytesIn []byte, xHubSignature string) error {
+
 	var validated error
 
+	secretKey, err := ioutil.ReadFile(derekSecretKey)
+
+	if err != nil {
+		return fmt.Errorf("unable to read GitHub symmetrical secret: %s, error: %s", derekSecretKey, err)
+	}
+
 	if len(xHubSignature) > 5 {
+
 		messageMAC := xHubSignature[5:] // first few chars are: sha1=
 		messageMACBuf, _ := hex.DecodeString(messageMAC)
+		secretKey = bytes.TrimRight(secretKey, "\n")
 
-		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), secretKey)
 		if res == false {
 			validated = fmt.Errorf("invalid message digest or secret")
 		}

--- a/auth/jwt_auth.go
+++ b/auth/jwt_auth.go
@@ -8,15 +8,14 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
-// GetSignedJwtToken get a tokens signed with private key
-func GetSignedJwtToken(appID, keyPath string) (string, error) {
-	if len(keyPath) == 0 {
-		return "", fmt.Errorf("unable to read from empty keypath, try setting env: \"private_key\" to a filename and path")
-	}
+const privateKeyPath = "/run/secrets/derek-private-key"
 
-	keyBytes, err := ioutil.ReadFile(keyPath)
+// GetSignedJwtToken get a tokens signed with private key
+func GetSignedJwtToken(appID string) (string, error) {
+
+	keyBytes, err := ioutil.ReadFile(privateKeyPath)
 	if err != nil {
-		return "", fmt.Errorf("unable to read keypath: %s, error: %s", keyPath, err)
+		return "", fmt.Errorf("unable to read private key path: %s, error: %s", privateKeyPath, err)
 	}
 
 	key, keyErr := jwt.ParseRSAPrivateKeyFromPEM(keyBytes)

--- a/commentHandler.go
+++ b/commentHandler.go
@@ -32,9 +32,8 @@ func makeClient(installation int) (*github.Client, context.Context) {
 	if len(token) == 0 {
 
 		applicationID := os.Getenv("application")
-		privateKeyPath := os.Getenv("private_key")
 
-		newToken, tokenErr := auth.MakeAccessTokenForInstallation(applicationID, installation, privateKeyPath)
+		newToken, tokenErr := auth.MakeAccessTokenForInstallation(applicationID, installation)
 		if tokenErr != nil {
 			log.Fatalln(tokenErr.Error())
 		}

--- a/main.go
+++ b/main.go
@@ -21,18 +21,19 @@ func hmacValidation() bool {
 }
 
 func main() {
+
 	bytesIn, _ := ioutil.ReadAll(os.Stdin)
 
 	xHubSignature := os.Getenv("Http_X_Hub_Signature")
+
 	if hmacValidation() && len(xHubSignature) == 0 {
 		log.Fatal("must provide X_Hub_Signature")
 		return
 	}
 
 	if len(xHubSignature) > 0 {
-		secretKey := os.Getenv("secret_key")
 
-		err := auth.ValidateHMAC(bytesIn, xHubSignature, secretKey)
+		err := auth.ValidateHMAC(bytesIn, xHubSignature)
 		if err != nil {
 			log.Fatal(err.Error())
 			return

--- a/pullRequestHandler.go
+++ b/pullRequestHandler.go
@@ -18,10 +18,8 @@ func handlePullRequest(req types.PullRequestOuter) {
 
 	token := os.Getenv("access_token")
 	if len(token) == 0 {
-		newToken, tokenErr := auth.MakeAccessTokenForInstallation(
-			os.Getenv("application"),
-			req.Installation.ID,
-			os.Getenv("private_key"))
+
+		newToken, tokenErr := auth.MakeAccessTokenForInstallation(os.Getenv("application"), req.Installation.ID)
 
 		if tokenErr != nil {
 			log.Fatalln(tokenErr.Error())

--- a/stack.yml
+++ b/stack.yml
@@ -8,7 +8,6 @@ functions:
     image: derek
     lang: Dockerfile
     environment:
-      installation: <your_GH_installationID>
       application: <your_GH_applicationID>
       validate_hmac: true
       debug: true

--- a/stack.yml
+++ b/stack.yml
@@ -3,15 +3,15 @@ provider:
   gateway: http://localhost:8080  # can be a remote server
 
 functions:
-  open-derek:
-    handler: ./
-    image: derek:0.1.1
+  derek:
+    handler: ./derek
+    image: derek
     lang: Dockerfile
     environment:
-      secret_key: secret_key_here
-      installation: installation_number
-      private_key: derek.pem
-      application: application_number
+      installation: <your_GH_installationID>
+      application: <your_GH_applicationID>
       validate_hmac: true
       debug: true
-
+    secrets:
+      - derek-secret-key
+      - derek-private-key


### PR DESCRIPTION
Fixes #41 

Derek will now read the symmetric and private keys from platform secrets.
Much of this change resides in the auth package which was using a combination
of files built in to the image and environment variables to achieve GitHub
authentication.  These have been replaced by /run/secrets/derek_private_key
and /run/secrets/derek_secret_key.

Also significantly updated GET.md

Signed-off-by: rgee0 <richard@technologee.co.uk>