### PR TITLE
Add support for `assign reviewer`

### DIFF
--- a/handler/commentHandler_test.go
+++ b/handler/commentHandler_test.go
@@ -515,3 +515,44 @@ func Test_isDcoLabel(t *testing.T) {
 		})
 	}
 }
+
+func Test_Parsing_Reviewers(t *testing.T) {
+
+	var reviewersOptions = []struct {
+		title        string
+		body         string
+		expectedType string
+		expectedVal  string
+	}{
+		{
+			title:        "Parse request to assign reviewer with valid message",
+			body:         "set reviewer: john",
+			expectedType: "AssignReviewer",
+			expectedVal:  "john",
+		},
+		{
+			title:        "Parse request to unassign reviewer with valid message",
+			body:         "clear reviewer: john",
+			expectedType: "UnassignReviewer",
+			expectedVal:  "john",
+		},
+		{
+			title:        "Parse request to assign reviewer with invalid message",
+			body:         "random message: john",
+			expectedType: "",
+			expectedVal:  "",
+		},
+	}
+
+	for _, test := range reviewersOptions {
+		t.Run(test.title, func(t *testing.T) {
+
+			for _, trigger := range commandTriggers {
+				action := parse(trigger+test.body, trigger)
+				if action.Type != test.expectedType || action.Value != test.expectedVal {
+					t.Errorf("Action - wanted: %s, got %s\nResult - wanted: %s, got %s", test.expectedType, action.Type, test.expectedVal, action.Value)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds  support for comments like `Derek assign reviewer: username`.

Works only with a single reviewer for the moment.

Raised in issue [#48](https://github.com/alexellis/derek/issues/48)

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

<img width="924" alt="screen shot 2018-11-22 at 17 18 53" src="https://user-images.githubusercontent.com/4160133/48911173-c696ea00-ee7a-11e8-9f5f-02ea40295292.png">

After updating the comment:

<img width="944" alt="screen shot 2018-11-22 at 17 59 17" src="https://user-images.githubusercontent.com/4160133/48913225-702caa00-ee80-11e8-952c-22d8ee82a917.png">

Unit tested
