### PR TITLE
[Merge/release] Accommodate custom .CUSTOMERS via ENV var

### DIFF
--- a/GET.md
+++ b/GET.md
@@ -40,7 +40,7 @@ $ docker build -t derek .
 
 ### Configure stack.yml:
 
-This is where Derek finds the details he needs to do the work he does.  The main area that will need to be updated is the application variable.  The gateway value may also need amending if the gateway is remote.
+This is where Derek finds the details he needs to do the work he does.  The main areas that will need to be updated are the `application` and `customer_url` variables.  The gateway value may also need amending if the gateway is remote.
 
 ``` yml
 provider:
@@ -52,15 +52,18 @@ functions:
     handler: ./derek
     image: derek
     lang: Dockerfile
-  environment:
-    application: <your_GH_applicationID>
-    validate_hmac: true
-    debug: true
-  secrets:
-    - derek-secret-key
-    - derek-private-key
+    environment:
+      application: <your_GH_applicationID>
+      customer_url: <your_customers_file_url>
+      validate_hmac: true
+      debug: true
+    secrets:
+      - derek-secret-key
+      - derek-private-key
 ```
 Fill out the `application` variable with the ID of the registered Derek GitHub App.
+
+Provide an `https` location of your `.CUSTOMERS` file.  If hosted on GitHub then this should be location obtained from raw.
 
 Validating via a symmetric key is also known as HMAC. If the webhook secret wasn't set earlier and you want to turn this off (to edit and debug) then set `validate_hmac="false"`
 

--- a/auth/customers.go
+++ b/auth/customers.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -8,6 +9,22 @@ import (
 
 	"github.com/alexellis/derek/types"
 )
+
+const defaultCustomersURL string = "https://raw.githubusercontent.com/alexellis/derek/master/.CUSTOMERS"
+const customersURLEnv string = "customers_url"
+
+func findCustomersURL() string {
+
+	if customURL, exists := os.LookupEnv(customersURLEnv); exists && (len(customURL) > 0) {
+
+		if !strings.HasPrefix(strings.ToLower(customURL), "http") {
+			customURL = fmt.Sprintf("https://%s", customURL)
+		}
+
+		return customURL
+	}
+	return defaultCustomersURL
+}
 
 func IsCustomer(repo types.Repository) (bool, error) {
 	validate := os.Getenv("validate_customers")
@@ -18,7 +35,8 @@ func IsCustomer(repo types.Repository) (bool, error) {
 	var err error
 	var found bool
 	c := http.Client{}
-	request, _ := http.NewRequest(http.MethodGet, "https://raw.githubusercontent.com/alexellis/derek/master/.CUSTOMERS", nil)
+	customersURL := findCustomersURL()
+	request, _ := http.NewRequest(http.MethodGet, customersURL, nil)
 	res, doErr := c.Do(request)
 	if err != nil {
 		err = doErr

--- a/auth/customers_test.go
+++ b/auth/customers_test.go
@@ -1,0 +1,46 @@
+package auth
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_findCustomerURL(t *testing.T) {
+
+	var URIOpts = []struct {
+		title       string
+		envVar      string
+		expectedURL string
+	}{
+		{
+			title:       "No ENV var",
+			envVar:      "",
+			expectedURL: defaultCustomersURL,
+		},
+		{
+			title:       "ENV var exists",
+			envVar:      "https://raw.githubusercontent.com/rgee0/derek/master/.CUSTOMERS",
+			expectedURL: "https://raw.githubusercontent.com/rgee0/derek/master/.CUSTOMERS",
+		},
+		{
+			title:       "Invalid ENV var exists",
+			envVar:      "raw.githubusercontent.com/rgee0/derek/master/.CUSTOMERS",
+			expectedURL: "https://raw.githubusercontent.com/rgee0/derek/master/.CUSTOMERS",
+		},
+	}
+
+	for _, test := range URIOpts {
+		t.Run(test.title, func(t *testing.T) {
+
+			os.Setenv(customersURLEnv, test.envVar)
+
+			customersURL := findCustomersURL()
+
+			os.Unsetenv(customersURLEnv)
+
+			if customersURL != test.expectedURL {
+				t.Errorf("customer URL - wrong URL found - wanted: %s, found %s", test.expectedURL, customersURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The existing location of the .CUSTOMERS file is hard-coded which means
that anyone self hosting will need to either add an entry into the project
.CUSTOMERS, or alter the source code to point at their own location.

This change enables an over-ride of the default .CUSTOMERS location by
setting an `customers_url` environment variable.  The location should
be an `https` endpoint.

Test added for the new function which attempts to read the ENV var and
GET.md updated to include `customers_url` in the stack file section.

Signed-off-by: rgee0 <richard@technologee.co.uk>

## Motivation and Context
- [x] I have raised an issue to propose this change (fixes #52)

## How Has This Been Tested?

Tested a number of scenarios on a DigitalOcean machine.

* Ran in default mode and confirmed as functioning as intended
* Ran with `customers_url: https://raw.githubusercontent.com/rgee0/Test/master/.CUSTOMERS` which **didn't** contain `rgee0`: 

```
derek.1.zcextiz4jcr8@derek    | 2018/04/22 19:07:40 Forking fprocess.
derek.1.zcextiz4jcr8@derek    | 2018/04/22 19:07:40 Query  
derek.1.zcextiz4jcr8@derek    | 2018/04/22 19:07:40 Path  /function/derek
derek.1.zcextiz4jcr8@derek    | 2018/04/22 19:07:40 stderr: time="2018-04-22T19:07:40Z" level=fatal msg="No customer found for: rgee0/Test"
derek.1.zcextiz4jcr8@derek    | 2018/04/22 19:07:40 Success=false, Error=exit status 1
derek.1.zcextiz4jcr8@derek    | 2018/04/22 19:07:40 Out=
```
* Ran with `customers_url: raw.githubusercontent.com/rgee0/Test/master/.CUSTOMERS` which **didn't** contain `rgee0`: 

```
derek.1.l41j9x9d4tnz@derek    | 2018/04/22 19:11:19 Forking fprocess.
derek.1.l41j9x9d4tnz@derek    | 2018/04/22 19:11:19 Query  
derek.1.l41j9x9d4tnz@derek    | 2018/04/22 19:11:19 Path  /function/derek
derek.1.l41j9x9d4tnz@derek    | 2018/04/22 19:11:19 stderr: time="2018-04-22T19:11:19Z" level=fatal msg="No customer found for: rgee0/Test"
derek.1.l41j9x9d4tnz@derek    | 2018/04/22 19:11:19 Success=false, Error=exit status 1
derek.1.l41j9x9d4tnz@derek    | 2018/04/22 19:11:19 Out=
```
* Ran with `customers_url: raw.githubusercontent.com/rgee0/Test/master/.CUSTOMERS` which **did** contain `rgee0`: 

```
derek.1.l41j9x9d4tnz@derek    | 2018/04/22 19:12:55 Forking fprocess.
derek.1.l41j9x9d4tnz@derek    | 2018/04/22 19:12:55 Query  
derek.1.l41j9x9d4tnz@derek    | 2018/04/22 19:12:55 Path  /function/derek
derek.1.l41j9x9d4tnz@derek    | rgee0 wants to add label of 'fred' on issue #8 
derek.1.l41j9x9d4tnz@derek    | 2018/04/22 19:12:56 Duration: 1.263511 seconds
```
* Ran with `customers_url: https://raw.githubusercontent.com/rgee0/Test/master/.CUSTOMERS` which **did** contain `rgee0`: 
```
derek.1.ty4gf05lfayb@derek    | 2018/04/22 19:14:35 Forking fprocess.
derek.1.ty4gf05lfayb@derek    | 2018/04/22 19:14:35 Query  
derek.1.ty4gf05lfayb@derek    | 2018/04/22 19:14:35 Path  /function/derek
derek.1.ty4gf05lfayb@derek    | rgee0 wants to add label of 'fred' on issue #8 
derek.1.ty4gf05lfayb@derek    | 2018/04/22 19:14:36 Duration: 1.042601 seconds
```
* Ran with `customers_url: https://raw.githubusercontent.com/rgee0/Test/master/.CONSUMERS` which **didnt** exist: 
```
derek.1.z8r0vvm6dk96@derek    | 2018/04/22 19:22:41 Forking fprocess.
derek.1.z8r0vvm6dk96@derek    | 2018/04/22 19:22:41 Query  
derek.1.z8r0vvm6dk96@derek    | 2018/04/22 19:22:41 Path  /function/derek
derek.1.z8r0vvm6dk96@derek    | 2018/04/22 19:22:41 stderr: time="2018-04-22T19:22:41Z" level=fatal msg="No customer found for: rgee0/Test"
derek.1.z8r0vvm6dk96@derek    | 2018/04/22 19:22:41 Success=false, Error=exit status 1
derek.1.z8r0vvm6dk96@derek    | 2018/04/22 19:22:41 Out=
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
