### PR TITLE
[WIP] Add privateKeyPath param to MakeAccessTokenForInstallation

### DIFF
--- a/auth/client_factory.go
+++ b/auth/client_factory.go
@@ -19,8 +19,9 @@ type JwtAuth struct {
 }
 
 // MakeAccessTokenForInstallation makes an access token for an installation / private key
-func MakeAccessTokenForInstallation(appID string, installation int) (string, error) {
-	signed, err := GetSignedJwtToken(appID)
+func MakeAccessTokenForInstallation(appID string, installation int, privateKeyPath string) (string, error) {
+
+	signed, err := GetSignedJwtToken(appID, privateKeyPath)
 
 	if err == nil {
 		c := http.Client{}

--- a/auth/jwt_auth.go
+++ b/auth/jwt_auth.go
@@ -8,10 +8,14 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
-const privateKeyPath = "/run/secrets/derek-private-key"
+const secretKeyPath = "/run/secrets/derek-private-key"
 
 // GetSignedJwtToken get a tokens signed with private key
-func GetSignedJwtToken(appID string) (string, error) {
+func GetSignedJwtToken(appID string, privateKeyPath string) (string, error) {
+
+	if privateKeyPath == "" {
+		privateKeyPath = secretKeyPath
+	}
 
 	keyBytes, err := ioutil.ReadFile(privateKeyPath)
 	if err != nil {

--- a/commentHandler.go
+++ b/commentHandler.go
@@ -24,6 +24,7 @@ const assignConstant string = "Assign"
 const unassignConstant string = "Unassign"
 const removeLabelConstant string = "RemoveLabel"
 const addLabelConstant string = "AddLabel"
+const useSecretKeyPath = ""
 
 func makeClient(installation int) (*github.Client, context.Context) {
 	ctx := context.Background()
@@ -33,7 +34,7 @@ func makeClient(installation int) (*github.Client, context.Context) {
 
 		applicationID := os.Getenv("application")
 
-		newToken, tokenErr := auth.MakeAccessTokenForInstallation(applicationID, installation)
+		newToken, tokenErr := auth.MakeAccessTokenForInstallation(applicationID, installation, useSecretKeyPath)
 		if tokenErr != nil {
 			log.Fatalln(tokenErr.Error())
 		}

--- a/pullRequestHandler.go
+++ b/pullRequestHandler.go
@@ -19,7 +19,7 @@ func handlePullRequest(req types.PullRequestOuter) {
 	token := os.Getenv("access_token")
 	if len(token) == 0 {
 
-		newToken, tokenErr := auth.MakeAccessTokenForInstallation(os.Getenv("application"), req.Installation.ID)
+		newToken, tokenErr := auth.MakeAccessTokenForInstallation(os.Getenv("application"), req.Installation.ID, useSecretKeyPath)
 
 		if tokenErr != nil {
 			log.Fatalln(tokenErr.Error())


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
Add in the ability to over-ride the private key path so that anyone
vendoring the auth package can use a private key outside of the
standard secret location as used by Derek himself.

## Motivation and Context
- [ ] I have raised an issue to propose this change (Awaiting Issue)

## How Has This Been Tested?
In testing

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
