### PR TITLE
Support the loading of config files via URL redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ We are planning to add roles in the ROADMAP which will mean you can get even mor
 
 > Note that the assign/unassign commands provides the shortcut `me` to assign to the commenter
 
+* URL redirection of configuration files is supported via the "redirect" field:
+
+```
+redirect: https://github.com/<some-user>/<some-repo>/.DEREK.yaml
+```
+
+If this optional field is non-empty, Derek will read it's configuration from another location. This allows multiple projects to use the same configuration.
+Please note that redirection is only supported for GitHub repository URLs.
+
 ### Examples:
 
 * Update the title of a PR or issue

--- a/permissionsHandler_test.go
+++ b/permissionsHandler_test.go
@@ -18,6 +18,42 @@ func Test_maintainersparsed(t *testing.T) {
 	}
 }
 
+func Test_validateRedirectURL(t *testing.T) {
+	type redirectURLTest struct {
+		URL         string
+		expectedErr bool
+	}
+	// append invalid domain tests
+	tests := []redirectURLTest{
+		redirectURLTest{
+			URL:         "http://somedomain.com",
+			expectedErr: true,
+		},
+		redirectURLTest{
+			URL:         "www.somedomain.com",
+			expectedErr: true,
+		},
+		redirectURLTest{
+			URL:         "www.somedomain.com/github.com",
+			expectedErr: true,
+		},
+	}
+	// append valid domain tests
+	for _, d := range getValidRedirectDomains() {
+		tests = append(tests,
+			redirectURLTest{URL: d, expectedErr: false},
+			redirectURLTest{URL: "http://" + d, expectedErr: false},
+			redirectURLTest{URL: "https://" + d, expectedErr: false},
+		)
+	}
+	for _, test := range tests {
+		err := validateRedirectURL(test.URL)
+		if (err != nil) != test.expectedErr {
+			t.Fatalf("URL: %q, expected error: %v, got: %v", test.URL, err != nil, test.expectedErr)
+		}
+	}
+}
+
 func Test_redirectparsed(t *testing.T) {
 	url := "some-url"
 	config := types.DerekConfig{}

--- a/permissionsHandler_test.go
+++ b/permissionsHandler_test.go
@@ -18,6 +18,17 @@ func Test_maintainersparsed(t *testing.T) {
 	}
 }
 
+func Test_redirectparsed(t *testing.T) {
+	url := "some-url"
+	config := types.DerekConfig{}
+	parseConfig([]byte(`redirect: `+url), &config)
+	actual := len(config.Redirect)
+	lenURL := len(url)
+	if actual != lenURL {
+		t.Errorf("want: redirect URL of size %d, got: %d", lenURL, actual)
+	}
+}
+
 func Test_curatorequalsmaintainer(t *testing.T) {
 	config := types.DerekConfig{}
 	parseConfig([]byte(`curators:

--- a/types/types.go
+++ b/types/types.go
@@ -64,6 +64,9 @@ type CommentAction struct {
 
 type DerekConfig struct {
 
+	// A redirect URL to load the config from another location.
+	Redirect string
+
 	// Features can be turned on/off if needed.
 	Features []string
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

this PR adds support for the optional `redirect` filed in `.DEREK.yaml` to allow jumping away from this config and loading another. the change is non-breaking for existing users.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))

spoke to @alexellis about this at KubeCon. :)
the idea is to allow multiple repos to use the same config file.

https://github.com/alexellis/derek/issues/58

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

pushed a test config to a github fork and added a temporary test in `permissionsHandler_test.go` (not included) that fetches the config from a redirected URL. then did a `go fmt`, `golint` and `go test -v` on the changes.

the best way to test this is to pull this branch and add this in the yaml:
```
redirect: <some-config-url>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
