### PR TITLE
[WIP] Accommodate OpenFaaS secrets location change

### DIFF
--- a/auth/hmac.go
+++ b/auth/hmac.go
@@ -7,9 +7,30 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 )
 
-const derekSecretKey = "/run/secrets/derek-secret-key"
+const derekSecretKey = "derek-secret-key"
+
+func getSecret(secretName string) (secretBytes []byte, err error) {
+
+	secretPaths := []string{"/var/openfaas/secrets/", "/run/secrets/"}
+
+	secretDir := filepath.Dir(secretName)
+	if len(secretDir) > 0 {
+		secretPaths = append([]string{secretDir}, secretPaths...)
+	}
+
+	secretName = filepath.Base(secretName)
+
+	for _, path := range secretPaths {
+		secretFile := filepath.Join(path, secretName)
+		if secret, err := ioutil.ReadFile(secretFile); err == nil {
+			return secret, nil
+		}
+	}
+	return nil, fmt.Errorf("unable to read secret: %s", secretName)
+}
 
 // CheckMAC verifies hash checksum
 func CheckMAC(message, messageMAC, key []byte) bool {
@@ -25,10 +46,10 @@ func ValidateHMAC(bytesIn []byte, xHubSignature string) error {
 
 	var validated error
 
-	secretKey, err := ioutil.ReadFile(derekSecretKey)
+	secretKey, err := getSecret(derekSecretKey)
 
 	if err != nil {
-		return fmt.Errorf("unable to read GitHub symmetrical secret: %s, error: %s", derekSecretKey, err)
+		return fmt.Errorf("unable to read GitHub symmetrical secret, error: %s", err)
 	}
 
 	if len(xHubSignature) > 5 {

--- a/auth/hmac_test.go
+++ b/auth/hmac_test.go
@@ -1,0 +1,79 @@
+package auth
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupSecret(secretName string) (string, error) {
+	//find temp location
+	dir := os.TempDir()
+	//make secrets folder there
+	secFolder := filepath.Join(dir, "derekTestSecrets")
+
+	if _, err := os.Stat(secFolder); os.IsNotExist(err) {
+		os.Mkdir(secFolder, 0777)
+	}
+	//write the file
+	secFile := filepath.Join(secFolder, secretName)
+
+	secretContents := fmt.Sprintf("Secret:%s", secretName)
+	fileErr := ioutil.WriteFile(secFile, []byte(secretContents), 0777)
+	if fileErr != nil {
+		return "", fileErr
+	}
+	return secFolder, nil
+}
+
+func Test_getSecretKey_notFound(t *testing.T) {
+
+	secretName := "derek-secret"
+
+	secDir, err := setupSecret(secretName)
+
+	if err != nil {
+		t.Errorf("secret setup failed: %s", err)
+		t.Fail()
+	}
+
+	defer os.RemoveAll(secDir)
+
+	_, err = getSecret(secretName)
+
+	if err == nil {
+		t.Errorf("getSecret should error as secret doesn't exist")
+		t.Fail()
+	}
+
+}
+
+func Test_getSecret_usingPath(t *testing.T) {
+
+	secretName := "derek-secret"
+	expected := fmt.Sprintf("Secret:%s", secretName)
+
+	secDir, err := setupSecret(secretName)
+
+	if err != nil {
+		t.Errorf("secret setup failed: %s", err)
+		t.Fail()
+	}
+
+	defer os.RemoveAll(secDir)
+
+	secretLocation := filepath.Join(secDir, secretName)
+
+	secretKey, err := getSecret(secretLocation)
+	if err != nil {
+		t.Errorf("getSecretKey failed: %s", err)
+		t.Fail()
+	}
+
+	if string(secretKey) != expected {
+		t.Errorf("want '%s' but got '%s'", expected, secretKey)
+		t.Fail()
+	}
+}

--- a/auth/jwt_auth.go
+++ b/auth/jwt_auth.go
@@ -2,18 +2,17 @@ package auth
 
 import (
 	"fmt"
-	"io/ioutil"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
 // GetSignedJwtToken get a tokens signed with private key
-func GetSignedJwtToken(appID string, privateKeyPath string) (string, error) {
+func GetSignedJwtToken(appID string, privateKey string) (string, error) {
 
-	keyBytes, err := ioutil.ReadFile(privateKeyPath)
+	keyBytes, err := getSecret(privateKey)
 	if err != nil {
-		return "", fmt.Errorf("unable to read private key path: %s, error: %s", privateKeyPath, err)
+		return "", fmt.Errorf("unable to read private key path: %s, error: %s", privateKey, err)
 	}
 
 	key, keyErr := jwt.ParseRSAPrivateKeyFromPEM(keyBytes)

--- a/commentHandler.go
+++ b/commentHandler.go
@@ -25,7 +25,7 @@ const unassignConstant string = "Unassign"
 const removeLabelConstant string = "RemoveLabel"
 const addLabelConstant string = "AddLabel"
 
-const privateKeyPath = "/run/secrets/derek-private-key"
+const privateKey = "derek-private-key"
 
 func makeClient(installation int) (*github.Client, context.Context) {
 	ctx := context.Background()
@@ -35,7 +35,7 @@ func makeClient(installation int) (*github.Client, context.Context) {
 
 		applicationID := os.Getenv("application")
 
-		newToken, tokenErr := auth.MakeAccessTokenForInstallation(applicationID, installation, privateKeyPath)
+		newToken, tokenErr := auth.MakeAccessTokenForInstallation(applicationID, installation, privateKey)
 		if tokenErr != nil {
 			log.Fatalln(tokenErr.Error())
 		}

--- a/pullRequestHandler.go
+++ b/pullRequestHandler.go
@@ -22,7 +22,7 @@ func handlePullRequest(req types.PullRequestOuter) {
 		newToken, tokenErr := auth.MakeAccessTokenForInstallation(
 			os.Getenv("application"),
 			req.Installation.ID,
-			privateKeyPath)
+			privateKey)
 
 		if tokenErr != nil {
 			log.Fatalln(tokenErr.Error())


### PR DESCRIPTION
WIP:
- Test beyond unit tests
- Address documentation around creating secrets

Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
This change adds functionality to default to the new location and fall back to legacy if the new location doesn't exist so that Derek will continue to operate either side of OpenFaaS 0.8.2

## Motivation and Context
Recent changes to OpenFaaS changed the storage location of secrets.
The current Derek implementation expects to find secrets in the (now) legacy location.
- [x] I have raised an issue to propose this change (fixes #59)

## How Has This Been Tested?
TBC

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.