### PR TITLE
Allow any prefix as trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curators:
 
 * What about roles?
 
-We are planning to add roles in the ROADMAP which will mean you can get even more granular and have folks who can only add labels but not close issues for instance. If you feel you need to make that distinction. It will also let you call the roles whatever you think makes sense. 
+We are planning to add roles in the ROADMAP which will mean you can get even more granular and have folks who can only add labels but not close issues for instance. If you feel you need to make that distinction. It will also let you call the roles whatever you think makes sense.
 
 > Note that the assign/unassign commands provides the shortcut `me` to assign to the commenter
 
@@ -161,4 +161,3 @@ Please follow the [OpenFaaS contribution guide](https://github.com/openfaas/faas
 To use our managed service (recommended) get in touch with [Alex Ellis](mailto:alex@openfaas.com) for more info. Once you have installed the GitHub App you will need to send a PR to the [customers file](https://github.com/alexellis/derek/blob/master/.CUSTOMERS) with your username or organisation. The final step is to add your .DEREK.yml - you can use the file from this repository as an example.
 
 You can host and manage your own Derek robot using [these instuctions](GET.md), or use our managed service.
-

--- a/commentHandler.go
+++ b/commentHandler.go
@@ -7,23 +7,29 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/alexellis/derek/auth"
 	"github.com/alexellis/derek/types"
+
+	log "github.com/Sirupsen/logrus"
 	"github.com/google/go-github/github"
 )
 
-const openConstant string = "open"
-const closedConstant string = "closed"
-const closeConstant string = "close"
-const reopenConstant string = "reopen"
-const lockConstant string = "Lock"
-const unlockConstant string = "Unlock"
-const setTitleConstant string = "SetTitle"
-const assignConstant string = "Assign"
-const unassignConstant string = "Unassign"
-const removeLabelConstant string = "RemoveLabel"
-const addLabelConstant string = "AddLabel"
+const (
+	openConst        string = "open"
+	closedConst      string = "closed"
+	closeConst       string = "close"
+	reopenConst      string = "reopen"
+	lockConst        string = "Lock"
+	unlockConst      string = "Unlock"
+	setTitleConst    string = "SetTitle"
+	assignConst      string = "Assign"
+	unassignConst    string = "Unassign"
+	removeLabelConst string = "RemoveLabel"
+	addLabelConst    string = "AddLabel"
+)
+
+// Trigger is the text that trigger action from this bot.
+const Trigger = "Derek "
 
 func makeClient(installation int) (*github.Client, context.Context) {
 	ctx := context.Background()
@@ -55,27 +61,27 @@ func handleComment(req types.IssueCommentOuter) {
 
 	switch command.Type {
 
-	case addLabelConstant, removeLabelConstant:
+	case addLabelConst, removeLabelConst:
 
 		feedback, err = manageLabel(req, command.Type, command.Value)
 		break
 
-	case assignConstant, unassignConstant:
+	case assignConst, unassignConst:
 
 		feedback, err = manageAssignment(req, command.Type, command.Value)
 		break
 
-	case closeConstant, reopenConstant:
+	case closeConst, reopenConst:
 
 		feedback, err = manageState(req, command.Type)
 		break
 
-	case setTitleConstant:
+	case setTitleConst:
 
 		feedback, err = manageTitle(req, command.Type, command.Value)
 		break
 
-	case lockConstant, unlockConstant:
+	case lockConst, unlockConst:
 
 		feedback, err = manageLocking(req, command.Type)
 		break
@@ -112,7 +118,7 @@ func manageLabel(req types.IssueCommentOuter, cmdType string, labelValue string)
 
 	found := findLabel(req.Issue.Labels, labelValue)
 
-	if !validAction(found, cmdType, addLabelConstant, removeLabelConstant) {
+	if !validAction(found, cmdType, addLabelConst, removeLabelConst) {
 		buffer.WriteString(fmt.Sprintf("Request to %s label of '%s' on issue #%d was unnecessary.", labelAction, labelValue, req.Issue.Number))
 		return buffer.String(), nil
 	}
@@ -121,7 +127,7 @@ func manageLabel(req types.IssueCommentOuter, cmdType string, labelValue string)
 
 	var err error
 
-	if cmdType == addLabelConstant {
+	if cmdType == addLabelConst {
 		_, _, err = client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, []string{labelValue})
 	} else {
 		_, err = client.Issues.RemoveLabelForIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, labelValue)
@@ -174,7 +180,7 @@ func manageAssignment(req types.IssueCommentOuter, cmdType string, cmdValue stri
 
 	var err error
 
-	if cmdType == unassignConstant {
+	if cmdType == unassignConst {
 		_, _, err = client.Issues.RemoveAssignees(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, []string{cmdValue})
 	} else {
 		_, _, err = client.Issues.AddAssignees(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, []string{cmdValue})
@@ -220,7 +226,7 @@ func manageLocking(req types.IssueCommentOuter, cmdType string) (string, error) 
 
 	buffer.WriteString(fmt.Sprintf("%s wants to %s issue #%d\n", req.Comment.User.Login, strings.ToLower(cmdType), req.Issue.Number))
 
-	if !validAction(req.Issue.Locked, cmdType, lockConstant, unlockConstant) {
+	if !validAction(req.Issue.Locked, cmdType, lockConst, unlockConst) {
 
 		buffer.WriteString(fmt.Sprintf("Issue #%d is already %sed\n", req.Issue.Number, strings.ToLower(cmdType)))
 
@@ -231,7 +237,7 @@ func manageLocking(req types.IssueCommentOuter, cmdType string) (string, error) 
 
 	var err error
 
-	if cmdType == lockConstant {
+	if cmdType == lockConst {
 		_, err = client.Issues.Lock(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number)
 	} else {
 		_, err = client.Issues.Unlock(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number)
@@ -250,16 +256,16 @@ func parse(body string) *types.CommentAction {
 	commentAction := types.CommentAction{}
 
 	commands := map[string]string{
-		"Derek add label: ":    addLabelConstant,
-		"Derek remove label: ": removeLabelConstant,
-		"Derek assign: ":       assignConstant,
-		"Derek unassign: ":     unassignConstant,
-		"Derek close":          closeConstant,
-		"Derek reopen":         reopenConstant,
-		"Derek set title: ":    setTitleConstant,
-		"Derek edit title: ":   setTitleConstant,
-		"Derek lock":           lockConstant,
-		"Derek unlock":         unlockConstant,
+		Trigger + "add label: ":    addLabelConst,
+		Trigger + "remove label: ": removeLabelConst,
+		Trigger + "assign: ":       assignConst,
+		Trigger + "unassign: ":     unassignConst,
+		Trigger + "close":          closeConst,
+		Trigger + "reopen":         reopenConst,
+		Trigger + "set title: ":    setTitleConst,
+		Trigger + "edit title: ":   setTitleConst,
+		Trigger + "lock":           lockConst,
+		Trigger + "unlock":         unlockConst,
 	}
 
 	for trigger, commandType := range commands {
@@ -289,10 +295,10 @@ func validAction(running bool, requestedAction string, start string, stop string
 
 func checkTransition(requestedAction string, currentState string) (string, bool) {
 
-	if requestedAction == closeConstant && currentState != closedConstant {
-		return closedConstant, true
-	} else if requestedAction == reopenConstant && currentState != openConstant {
-		return openConstant, true
+	if requestedAction == closeConst && currentState != closedConst {
+		return closedConst, true
+	} else if requestedAction == reopenConst && currentState != openConst {
+		return openConst, true
 	}
 
 	return "", false

--- a/commentHandler_test.go
+++ b/commentHandler_test.go
@@ -13,28 +13,28 @@ var actionOptions = []struct {
 }{
 	{
 		title:          "Correct reopen command",
-		body:           "Derek reopen",
-		expectedAction: "reopen",
+		body:           Trigger + "reopen",
+		expectedAction: reopenConst,
 	},
 	{ //this case replaces Test_Parsing_Close
 		title:          "Correct close command",
-		body:           "Derek close",
-		expectedAction: "close",
+		body:           Trigger + "close",
+		expectedAction: closeConst,
 	},
 	{
 		title:          "invalid command",
-		body:           "Derek dance",
+		body:           Trigger + "dance",
 		expectedAction: "",
 	},
 	{
 		title:          "Longer reopen command",
-		body:           "Derek reopen: ",
-		expectedAction: "reopen",
+		body:           Trigger + "reopen: ",
+		expectedAction: reopenConst,
 	},
 	{
 		title:          "Longer close command",
-		body:           "Derek close: ",
-		expectedAction: "close",
+		body:           Trigger + "close: ",
+		expectedAction: closeConst,
 	},
 }
 
@@ -103,25 +103,25 @@ func Test_Parsing_Assignments(t *testing.T) {
 		{
 			title:        "Assign to burt",
 			body:         "Derek assign: burt",
-			expectedType: assignConstant,
+			expectedType: assignConst,
 			expectedVal:  "burt",
 		},
 		{
 			title:        "Unassign burt",
 			body:         "Derek unassign: burt",
-			expectedType: unassignConstant,
+			expectedType: unassignConst,
 			expectedVal:  "burt",
 		},
 		{
 			title:        "Assign to me",
 			body:         "Derek assign: me",
-			expectedType: assignConstant,
+			expectedType: assignConst,
 			expectedVal:  "me",
 		},
 		{
 			title:        "Unassign me",
 			body:         "Derek unassign: me",
-			expectedType: unassignConstant,
+			expectedType: unassignConst,
 			expectedVal:  "me",
 		},
 		{
@@ -160,7 +160,7 @@ func Test_Parsing_Titles(t *testing.T) {
 		{
 			title:        "Set Title",
 			body:         "Derek set title: This is a really great Title!",
-			expectedType: setTitleConstant,
+			expectedType: setTitleConst,
 			expectedVal:  "This is a really great Title!",
 		},
 		{
@@ -178,7 +178,7 @@ func Test_Parsing_Titles(t *testing.T) {
 		{
 			title:        "Empty Title (Double Space)",
 			body:         "Derek set title:  ",
-			expectedType: setTitleConstant,
+			expectedType: setTitleConst,
 			expectedVal:  "",
 		},
 	}
@@ -205,30 +205,30 @@ func Test_assessState(t *testing.T) {
 	}{
 		{
 			title:            "Currently Closed and trying to close",
-			requestedAction:  closeConstant,
-			currentState:     closedConstant,
+			requestedAction:  closeConst,
+			currentState:     closedConst,
 			expectedNewState: "",
 			expectedBool:     false,
 		},
 		{
 			title:            "Currently Open and trying to reopen",
-			requestedAction:  reopenConstant,
-			currentState:     openConstant,
+			requestedAction:  reopenConst,
+			currentState:     openConst,
 			expectedNewState: "",
 			expectedBool:     false,
 		},
 		{
 			title:            "Currently Closed and trying to open",
-			requestedAction:  reopenConstant,
-			currentState:     closedConstant,
-			expectedNewState: openConstant,
+			requestedAction:  reopenConst,
+			currentState:     closedConst,
+			expectedNewState: openConst,
 			expectedBool:     true,
 		},
 		{
 			title:            "Currently Open and trying to close",
-			requestedAction:  closeConstant,
-			currentState:     openConstant,
-			expectedNewState: closedConstant,
+			requestedAction:  closeConst,
+			currentState:     openConst,
+			expectedNewState: closedConst,
 			expectedBool:     true,
 		},
 	}
@@ -258,33 +258,33 @@ func Test_validAction(t *testing.T) {
 		{
 			title:           "Currently unlocked and trying to lock",
 			running:         false,
-			requestedAction: lockConstant,
-			start:           lockConstant,
-			stop:            unlockConstant,
+			requestedAction: lockConst,
+			start:           lockConst,
+			stop:            unlockConst,
 			expectedBool:    true,
 		},
 		{
 			title:           "Currently unlocked and trying to unlock",
 			running:         false,
-			requestedAction: unlockConstant,
-			start:           lockConstant,
-			stop:            unlockConstant,
+			requestedAction: unlockConst,
+			start:           lockConst,
+			stop:            unlockConst,
 			expectedBool:    false,
 		},
 		{
 			title:           "Currently locked and trying to lock",
 			running:         true,
-			requestedAction: lockConstant,
-			start:           lockConstant,
-			stop:            unlockConstant,
+			requestedAction: lockConst,
+			start:           lockConst,
+			stop:            unlockConst,
 			expectedBool:    false,
 		},
 		{
 			title:           "Currently locked and trying to unlock",
 			running:         true,
-			requestedAction: unlockConstant,
-			start:           lockConstant,
-			stop:            unlockConstant,
+			requestedAction: unlockConst,
+			start:           lockConst,
+			stop:            unlockConst,
 			expectedBool:    true,
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -6,14 +6,17 @@ import (
 	"io/ioutil"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/alexellis/derek/auth"
 	"github.com/alexellis/derek/types"
+
+	log "github.com/Sirupsen/logrus"
 )
 
-const dcoCheck = "dco_check"
-const comments = "comments"
-const deleted = "deleted"
+const (
+	dcoCheck = "dco_check"
+	comments = "comments"
+	deleted  = "deleted"
+)
 
 func hmacValidation() bool {
 	val := os.Getenv("validate_hmac")
@@ -68,7 +71,7 @@ func handleEvent(eventType string, bytesIn []byte) error {
 		if err != nil {
 			return fmt.Errorf("Unable to access maintainers file at: %s/%s", req.Repository.Owner.Login, req.Repository.Name)
 		}
-		if req.Action != closedConstant {
+		if req.Action != closedConst {
 			if enabledFeature(dcoCheck, derekConfig) {
 				handlePullRequest(req)
 			}

--- a/permissionsHandler.go
+++ b/permissionsHandler.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/alexellis/derek/types"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/alexellis/derek/types"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const configFile = ".DEREK.yml"

--- a/pullRequestHandler.go
+++ b/pullRequestHandler.go
@@ -3,13 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
-	"os"
-
-	log "github.com/Sirupsen/logrus"
 	"github.com/alexellis/derek/auth"
 	"github.com/alexellis/derek/types"
+
+	log "github.com/Sirupsen/logrus"
 	"github.com/google/go-github/github"
 )
 


### PR DESCRIPTION
use Trigger to set the prefix for triggering derek, currently set
to "Derek ", but "//" is useful as well.

Use `Const` instead of Contant for constants and clean up import lines

Signed-off-by: Miek Gieben <miek@miek.nl>