### PR TITLE
Add label to people who contribute for the first time

### DIFF
--- a/pullRequestHandler.go
+++ b/pullRequestHandler.go
@@ -39,12 +39,12 @@ func handlePullRequest(req types.PullRequestOuter) {
 
 	hasUnsignedCommits, err := hasUnsigned(req, client)
 
-	authorAssociation := req.PullRequest.AuthorAssociation
-
-	if firstTimeContributor(authorAssociation) == true {
-		_, res, assignLabelErr := client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, []string{"new-contributor"})
-		if assignLabelErr != nil {
-			log.Fatalf("%s limit: %d, remaining: %d", assignLabelErr, res.Limit, res.Remaining)
+	if req.Action == "opened" {
+		if req.PullRequest.FirstTimeContributor() == true {
+			_, res, assignLabelErr := client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, []string{"new-contributor"})
+			if assignLabelErr != nil {
+				log.Fatalf("%s limit: %d, remaining: %d", assignLabelErr, res.Limit, res.Remaining)
+			}
 		}
 	}
 
@@ -142,11 +142,4 @@ func hasUnsigned(req types.PullRequestOuter, client *github.Client) (bool, error
 
 func isSigned(msg string) bool {
 	return strings.Contains(msg, "Signed-off-by:")
-}
-
-func firstTimeContributor(label string) bool {
-	if label == "NONE" {
-		return true
-	}
-	return false
 }

--- a/pullRequestHandler.go
+++ b/pullRequestHandler.go
@@ -39,6 +39,15 @@ func handlePullRequest(req types.PullRequestOuter) {
 
 	hasUnsignedCommits, err := hasUnsigned(req, client)
 
+	authorAssociation := req.PullRequest.AuthorAssociation
+
+	if firstTimeContributor(authorAssociation) == true {
+		_, res, assignLabelErr := client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, []string{"new-contributor"})
+		if assignLabelErr != nil {
+			log.Fatalf("%s limit: %d, remaining: %d", assignLabelErr, res.Limit, res.Remaining)
+		}
+	}
+
 	if err != nil {
 		log.Fatal(err)
 	} else if hasUnsignedCommits {
@@ -133,4 +142,11 @@ func hasUnsigned(req types.PullRequestOuter, client *github.Client) (bool, error
 
 func isSigned(msg string) bool {
 	return strings.Contains(msg, "Signed-off-by:")
+}
+
+func firstTimeContributor(label string) bool {
+	if label == "NONE" {
+		return true
+	}
+	return false
 }

--- a/pullRequestHandler_test.go
+++ b/pullRequestHandler_test.go
@@ -109,19 +109,15 @@ func Test_firstTimeContributor(t *testing.T) {
 			expectedBool: false,
 		},
 		{
-			label:        "CONTRIBUTOR",
+			label:        "OWNER",
 			expectedBool: false,
-		},
-		{
-			label:        "NONE",
-			expectedBool: true,
 		},
 	}
 	for _, test := range authorLabel {
 		t.Run(test.label, func(t *testing.T) {
 			isFirstTime := firstTimeContributor(test.label)
 			if isFirstTime != test.expectedBool {
-				t.Errorf("First time contributor - %s - wanted %t, found %t", test.label, test.expectedBool, isFirstTime)
+				t.Errorf("First time contributor - %s - want %t, got %t", test.label, test.expectedBool, isFirstTime)
 			}
 		})
 	}

--- a/pullRequestHandler_test.go
+++ b/pullRequestHandler_test.go
@@ -95,30 +95,3 @@ func Test_hasNoDcoLabel(t *testing.T) {
 		})
 	}
 }
-func Test_firstTimeContributor(t *testing.T) {
-	var authorLabel = []struct {
-		label        string
-		expectedBool bool
-	}{
-		{
-			label:        "NONE",
-			expectedBool: true,
-		},
-		{
-			label:        "CONTRIBUTOR",
-			expectedBool: false,
-		},
-		{
-			label:        "OWNER",
-			expectedBool: false,
-		},
-	}
-	for _, test := range authorLabel {
-		t.Run(test.label, func(t *testing.T) {
-			isFirstTime := firstTimeContributor(test.label)
-			if isFirstTime != test.expectedBool {
-				t.Errorf("First time contributor - %s - want %t, got %t", test.label, test.expectedBool, isFirstTime)
-			}
-		})
-	}
-}

--- a/pullRequestHandler_test.go
+++ b/pullRequestHandler_test.go
@@ -95,3 +95,34 @@ func Test_hasNoDcoLabel(t *testing.T) {
 		})
 	}
 }
+func Test_firstTimeContributor(t *testing.T) {
+	var authorLabel = []struct {
+		label        string
+		expectedBool bool
+	}{
+		{
+			label:        "NONE",
+			expectedBool: true,
+		},
+		{
+			label:        "CONTRIBUTOR",
+			expectedBool: false,
+		},
+		{
+			label:        "CONTRIBUTOR",
+			expectedBool: false,
+		},
+		{
+			label:        "NONE",
+			expectedBool: true,
+		},
+	}
+	for _, test := range authorLabel {
+		t.Run(test.label, func(t *testing.T) {
+			isFirstTime := firstTimeContributor(test.label)
+			if isFirstTime != test.expectedBool {
+				t.Errorf("First time contributor - %s - wanted %t, found %t", test.label, test.expectedBool, isFirstTime)
+			}
+		})
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -14,7 +14,8 @@ type Owner struct {
 }
 
 type PullRequest struct {
-	Number int `json:"number"`
+	Number            int    `json:"number"`
+	AuthorAssociation string `json:"author_association"`
 }
 
 type InstallationRequest struct {

--- a/types/types.go
+++ b/types/types.go
@@ -80,3 +80,7 @@ type DerekConfig struct {
 	// Curators is an alias for Maintainers and is only used if the Maintainers list is empty.
 	Curators []string
 }
+
+func (p *PullRequest) FirstTimeContributor() bool {
+	return p.AuthorAssociation == "NONE"
+}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"testing"
+)
+
+func Test_FirstTimeContributor(t *testing.T) {
+	type pullRequestTest struct {
+		pullRequest  PullRequest
+		expectedBool bool
+	}
+	authorLabel := []pullRequestTest{
+		pullRequestTest{
+			pullRequest:  PullRequest{AuthorAssociation: "NONE"},
+			expectedBool: true,
+		},
+		pullRequestTest{
+			pullRequest:  PullRequest{AuthorAssociation: "CONTRIBUTOR"},
+			expectedBool: false,
+		},
+		pullRequestTest{
+			pullRequest:  PullRequest{AuthorAssociation: "OWNER"},
+			expectedBool: false,
+		},
+	}
+	for _, test := range authorLabel {
+		t.Run(test.pullRequest.AuthorAssociation, func(t *testing.T) {
+			isFirstTime := test.pullRequest.FirstTimeContributor()
+			if isFirstTime != test.expectedBool {
+				t.Errorf("First time contributor - %s - want %t, got %t", test.pullRequest.AuthorAssociation, test.expectedBool, isFirstTime)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I added function so new contributors could be recognized by
the community.

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

Adding simple function so new people who contribute to project could be recognized
by the community.

## Description
<!--- Describe your changes in detail -->

Added firstTImeContributor function that checks if the webhook author_association has NONE 
if it does then the contributor is new.Also extended pullrequest struct in types.go to include
AuthorAssociation since from what i saw the field is part of PullRequest field the webhook gives.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))

https://github.com/alexellis/derek/issues/65
It adds new contributors tag to newcomers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I created test function in pullRequestHandler_test.go which passed. I also ran 
$ docker build -t derek .
which builded derek successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
