### PR TITLE
Update key paths for OpenFaaS 0.8.3

### DIFF
--- a/GET.md
+++ b/GET.md
@@ -66,17 +66,25 @@ Before deploying Derek create two secrets:
 
 For Docker:
 
-```
+```sh
 $ docker secret create derek-private-key derek-private-key
 $ docker secret create derek-secret-key derek-secret-key
 ```
 
 For Kubernetes:
 
-```
+```sh
 $ kubectl create secret generic derek-private-key --from-file=./derek-private-key
 $ kubectl create secret generic derek-secret-key --from-file=./derek-secret-key
 ```
+
+Create secrets.yml:
+
+```sh
+cp secrets.example.yml secrets.yml
+```
+
+Then populate your own values in the file - set `application` to your GitHub application ID and set `secret_key` to the same value of the `derek-secret-key` file.
 
 ### Configure Docker image:
 
@@ -92,7 +100,7 @@ This will build a Docker image in your local library, now push it to the Docker 
 
 ```
 $ docker login
-$ faas-cli push
+$ faas-cli push -f derek.yml
 ```
 
 ### Configure stack.yml:
@@ -116,6 +124,7 @@ functions:
       validate_hmac: true
       debug: true
       write_debug: false
+      secret_path: /var/openfaas/secrets/
     secrets:
       - derek-secret-key
       - derek-private-key
@@ -139,7 +148,6 @@ $ faas-cli deploy
 * `validate_hmac` - Validate all incoming webhooks are signed with the secret `derek-secret-key` that you enter in the GitHub UI
 * `write_debug` - Dump the incoming request to the function logs. This is not needed since the request can be viewed in the advanced tab of the GitHub App UI
 
-
 ### Configure GitHub Repo:
 
 Finally configure the features that you want to enable within your GitHub repo by creating a `.DEREK.yml` file.
@@ -156,8 +164,14 @@ features:
  - comments
 ```
 
-**Testing**
+### Testing and troubleshooting
+
+To test: 
 
 Create a label of "no-dco" within every project you want Derek to help you with.
  
 Head over to your GitHub repository and raise a Pull Request from the web-UI for your README file. This will not sign-off the commit, so you'll have Derek on your case.
+
+If you're not sure if things are working right then Click on the GitHub App via your account settings and then click "Advanced" and "Recent Deliveries". This will show you all the incoming messages and their responses.
+
+You can tweak your environment and then hit "Redeliver" to send the message again.

--- a/commentHandler.go
+++ b/commentHandler.go
@@ -30,8 +30,6 @@ const (
 	addLabelConstant    string = "AddLabel"
 )
 
-const privateKeyPath = "/run/secrets/derek-private-key"
-
 func makeClient(installation int) (*github.Client, context.Context) {
 	ctx := context.Background()
 
@@ -40,7 +38,13 @@ func makeClient(installation int) (*github.Client, context.Context) {
 
 		applicationID := os.Getenv("application")
 
-		newToken, tokenErr := auth.MakeAccessTokenForInstallation(applicationID, installation, privateKeyPath)
+		secretPath := os.Getenv("secret_path")
+
+		if len(secretPath) == 0 {
+			log.Printf("Must supply a value for env-var %s\n", "secret_path")
+		}
+
+		newToken, tokenErr := auth.MakeAccessTokenForInstallation(applicationID, installation, secretPath+privateKeyFile)
 		if tokenErr != nil {
 			log.Fatalln(tokenErr.Error())
 		}

--- a/derek.yml
+++ b/derek.yml
@@ -5,7 +5,7 @@ provider:
 functions:
   derek:
     handler: ./
-    image: alexellis/derek:0.5.1-rc1
+    image: alexellis/derek:0.5.2
     lang: dockerfile
     environment:
       debug: true

--- a/derek.yml
+++ b/derek.yml
@@ -5,18 +5,17 @@ provider:
 functions:
   derek:
     handler: ./
-    image: alexellis/derek:0.5.0
+    image: alexellis/derek:0.5.1-rc1
     lang: dockerfile
     environment:
       debug: true
       customers_url: https://raw.githubusercontent.com/alexellis/derek/master/.CUSTOMERS
       validate_hmac: false
       validate_customers: true
+      secret_path: /var/openfaas/secrets/ # use /run/secrets/ for older OpenFaaS versions
     environment_file:
       - secrets.yml
       # See secrets.example.yml
     secrets:
       - derek-secret-key
       - derek-private-key
-
-# Private key needs to be mounted at: /run/secrets/derek-private-key

--- a/pullRequestHandler.go
+++ b/pullRequestHandler.go
@@ -21,11 +21,12 @@ func handlePullRequest(req types.PullRequestOuter) {
 
 	token := os.Getenv("access_token")
 	if len(token) == 0 {
+		keyPath, _ := getSecretPath()
 
 		newToken, tokenErr := auth.MakeAccessTokenForInstallation(
 			os.Getenv("application"),
 			req.Installation.ID,
-			privateKeyPath)
+			keyPath+privateKeyFile)
 
 		if tokenErr != nil {
 			log.Fatalln(tokenErr.Error())

--- a/stack.example.yml
+++ b/stack.example.yml
@@ -13,6 +13,7 @@ functions:
       customers_url: https://raw.githubusercontent.com/alexellis/derek/master/.CUSTOMERS
       validate_hmac: false
       validate_customers: true
+      secret_path: /var/openfaas/secrets/ # use /run/secrets/ for older OpenFaaS versions
     secrets:
       - derek-secret-key
       - derek-private-key


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

A new change upstream means there are two potential paths for
secrets depending on the version used. This covers the scenario
by implementing a mandatory secret_path config item.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))

#59 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on GitHub / Swarm - bot created label correctly:

https://github.com/alexellis/store-gist/issues/2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

This change was in progress by @rgee0 but I had to bring it forward for some testing @mrtind is working on via #68 