### PR TITLE
Support slash as a command trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ redirect: https://github.com/<some-user>/<some-repo>/.DEREK.yaml
 If this optional field is non-empty, Derek will read it's configuration from another location. This allows multiple projects to use the same configuration.
 Please note that redirection is only supported for GitHub repository URLs.
 
+* Command triggers
+
+By default, Derek commands can be called with `Derek <some-command>`. The prefix `Derek ` is the default trigger, but the bot also supports the `/` trigger which can be enabled by setting the `use_slash_trigger` environment variable to `true`.
+
 ### Examples:
 
 * Update the title of a PR or issue

--- a/commentHandler.go
+++ b/commentHandler.go
@@ -31,7 +31,18 @@ const (
 	addLabelConstant        string = "AddLabel"
 	setMilestoneConstant    string = "SetMilestone"
 	removeMilestoneConstant string = "RemoveMilestone"
+
+	commandTriggerDefault string = "Derek "
+	commandTriggerSlash   string = "/"
 )
+
+func getCommandTrigger() string {
+	commandTrigger := commandTriggerDefault
+	if os.Getenv("use_slash_trigger") == "true" {
+		commandTrigger = commandTriggerSlash
+	}
+	return commandTrigger
+}
 
 func makeClient(installation int) (*github.Client, context.Context) {
 	ctx := context.Background()
@@ -65,7 +76,7 @@ func handleComment(req types.IssueCommentOuter) {
 	var feedback string
 	var err error
 
-	command := parse(req.Comment.Body)
+	command := parse(req.Comment.Body, getCommandTrigger())
 
 	switch command.Type {
 
@@ -319,23 +330,23 @@ func updateMilestone(req types.IssueCommentOuter, cmdType string, cmdValue strin
 	return buffer.String(), nil
 }
 
-func parse(body string) *types.CommentAction {
+func parse(body, commandTrigger string) *types.CommentAction {
 
 	commentAction := types.CommentAction{}
 
 	commands := map[string]string{
-		"Derek add label: ":        addLabelConstant,
-		"Derek remove label: ":     removeLabelConstant,
-		"Derek assign: ":           assignConstant,
-		"Derek unassign: ":         unassignConstant,
-		"Derek close":              closeConstant,
-		"Derek reopen":             reopenConstant,
-		"Derek set title: ":        setTitleConstant,
-		"Derek edit title: ":       setTitleConstant,
-		"Derek lock":               lockConstant,
-		"Derek unlock":             unlockConstant,
-		"Derek set milestone: ":    setMilestoneConstant,
-		"Derek remove milestone: ": removeMilestoneConstant,
+		commandTrigger + "add label: ":        addLabelConstant,
+		commandTrigger + "remove label: ":     removeLabelConstant,
+		commandTrigger + "assign: ":           assignConstant,
+		commandTrigger + "unassign: ":         unassignConstant,
+		commandTrigger + "close":              closeConstant,
+		commandTrigger + "reopen":             reopenConstant,
+		commandTrigger + "set title: ":        setTitleConstant,
+		commandTrigger + "edit title: ":       setTitleConstant,
+		commandTrigger + "lock":               lockConstant,
+		commandTrigger + "unlock":             unlockConstant,
+		commandTrigger + "set milestone: ":    setMilestoneConstant,
+		commandTrigger + "remove milestone: ": removeMilestoneConstant,
 	}
 
 	for trigger, commandType := range commands {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
me and Martin collaborated on this change over a couple of Zoom meetings.
please, let me know if this needs any changes.
/cc @rgee0 @alexellis 

## Description
<!--- Describe your changes in detail -->
Track the environment variable `use_slash_trigger`
and make it possible to use `/` as the command trigger
that the bot uses instead of "Derek ".

- Update unit tests in commentHandler_test.go.
- Update README.md

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>
Signed-off-by: Lubomir I. Ivanov (VMware) <neolit123@gmail.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))
https://github.com/alexellis/derek/issues/63

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit tests only on my side.
@mrtind and @ivanayov can possibly do an e2e if they have the setup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
