### PR TITLE
Remove newlines from file where webhook secret is stored

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/alexellis/derek/auth"
@@ -67,6 +68,10 @@ func main() {
 				keyPath+derekSecretKeyFile, readErr)
 			os.Stderr.Write([]byte(msg.Error()))
 			os.Exit(1)
+		}
+
+		if newLine := strings.Index(string(secretKeyBytes), "\n"); newLine != -1 {
+			secretKeyBytes = secretKeyBytes[:newLine]
 		}
 
 		err := hmac.Validate(bytesIn, xHubSignature, string(secretKeyBytes))

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func hmacValidation() bool {
 	return len(val) > 0 && (val == "1" || val == "true")
 }
 
-func removeNewLine(secret []byte) []byte {
+func getFirstLine(secret []byte) []byte {
 	stringSecret := string(secret)
 	if newLine := strings.Index(stringSecret, "\n"); newLine != -1 {
 		secret = secret[:newLine]
@@ -78,7 +78,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		secretKeyBytes = removeNewLine(secretKeyBytes)
+		secretKeyBytes = getFirstLine(secretKeyBytes)
 
 		err := hmac.Validate(bytesIn, xHubSignature, string(secretKeyBytes))
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -43,6 +43,14 @@ func hmacValidation() bool {
 	return len(val) > 0 && (val == "1" || val == "true")
 }
 
+func removeNewLine(secret []byte) []byte {
+	stringSecret := string(secret)
+	if newLine := strings.Index(stringSecret, "\n"); newLine != -1 {
+		secret = secret[:newLine]
+	}
+	return secret
+}
+
 func main() {
 
 	bytesIn, _ := ioutil.ReadAll(os.Stdin)
@@ -70,9 +78,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		if newLine := strings.Index(string(secretKeyBytes), "\n"); newLine != -1 {
-			secretKeyBytes = secretKeyBytes[:newLine]
-		}
+		secretKeyBytes = removeNewLine(secretKeyBytes)
 
 		err := hmac.Validate(bytesIn, xHubSignature, string(secretKeyBytes))
 		if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func Test_removeNewLine(t *testing.T) {
+	var exampleSecrets = []struct {
+		secret       string
+		expectedByte string
+	}{
+		{
+			secret:       "nline \n",
+			expectedByte: "nline ",
+		},
+		{
+			secret: `newline
+			`,
+			expectedByte: "newline",
+		},
+		{
+			secret:       `noline`,
+			expectedByte: `noline`,
+		},
+		{
+			secret:       "",
+			expectedByte: "",
+		},
+	}
+	for _, test := range exampleSecrets {
+
+		t.Run(string(test.secret), func(t *testing.T) {
+			stringNoLines := removeNewLine([]byte(test.secret))
+			if test.expectedByte != string(stringNoLines) {
+				t.Errorf("String after removal - wanted: \"%s\", got \"%s\"", test.expectedByte, test.secret)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -21,6 +21,10 @@ func Test_removeNewLine(t *testing.T) {
 			expectedByte: `Example secret2 `,
 		},
 		{
+			secret:       "\n",
+			expectedByte: "",
+		},
+		{
 			secret:       "",
 			expectedByte: "",
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,7 @@ package main
 
 import "testing"
 
-func Test_removeNewLine(t *testing.T) {
+func Test_getFirstLine(t *testing.T) {
 	var exampleSecrets = []struct {
 		secret       string
 		expectedByte string
@@ -32,7 +32,7 @@ func Test_removeNewLine(t *testing.T) {
 	for _, test := range exampleSecrets {
 
 		t.Run(string(test.secret), func(t *testing.T) {
-			stringNoLines := removeNewLine([]byte(test.secret))
+			stringNoLines := getFirstLine([]byte(test.secret))
 			if test.expectedByte != string(stringNoLines) {
 				t.Errorf("String after removal - wanted: \"%s\", got \"%s\"", test.expectedByte, test.secret)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -8,17 +8,17 @@ func Test_removeNewLine(t *testing.T) {
 		expectedByte string
 	}{
 		{
-			secret:       "nline \n",
-			expectedByte: "nline ",
+			secret:       "New-line \n",
+			expectedByte: "New-line ",
 		},
 		{
-			secret: `newline
+			secret: `Newline and text 
 			`,
-			expectedByte: "newline",
+			expectedByte: "Newline and text ",
 		},
 		{
-			secret:       `noline`,
-			expectedByte: `noline`,
+			secret:       `Example secret2 `,
+			expectedByte: `Example secret2 `,
 		},
 		{
 			secret:       "",


### PR DESCRIPTION
We need to check if newlines are present in the file where
we load our docker secrets from.Some editors may add extra
newline at the end making the secret invalid.

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

Adding check to see if newlines are present in the file from which we 
create docker secret for derek-secret-key.

## Description
<!--- Describe your changes in detail -->

Add check in main.go if newline is present in the secret string loaded from the 
file and if so it removes it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))

It solves issue #72.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
