### PR TITLE
Prevent maintainers to remove the no-dco label

### DIFF
--- a/commentHandler.go
+++ b/commentHandler.go
@@ -142,7 +142,12 @@ func manageLabel(req types.IssueCommentOuter, cmdType string, labelValue string)
 	if cmdType == addLabelConstant {
 		_, _, err = client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, []string{labelValue})
 	} else {
-		_, err = client.Issues.RemoveLabelForIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, labelValue)
+		if isDcoLabel(labelValue) {
+			buffer.WriteString(fmt.Sprintf("%s the request is not allowed.Label `%s` can be removed by owner or by signing out the commit.", req.Repository.Owner.Login, labelValue))
+			return buffer.String(), nil
+		} else {
+			_, err = client.Issues.RemoveLabelForIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, labelValue)
+		}
 	}
 
 	if err != nil {
@@ -380,4 +385,8 @@ func removeMilestone(client *github.Client, ctx context.Context, URL string) err
 		return err
 	}
 	return nil
+}
+
+func isDcoLabel(labelValue string) bool {
+	return strings.ToLower(labelValue) == "no-dco"
 }

--- a/commentHandler_test.go
+++ b/commentHandler_test.go
@@ -438,3 +438,46 @@ func Test_Parsing_Milestones(t *testing.T) {
 		})
 	}
 }
+
+func Test_isDcoLabel(t *testing.T) {
+	dcoLabel := []struct {
+		title        string
+		label        string
+		expectedBool bool
+	}{
+		{
+			title:        "Counts as no-dco - case insensitivity",
+			label:        "NO-DCO",
+			expectedBool: true,
+		},
+		{
+			title:        "Normal no-dco case",
+			label:        "no-dco",
+			expectedBool: true,
+		},
+		{
+			title:        "Counts as no-dco - case insensitivity",
+			label:        "No-Dco",
+			expectedBool: true,
+		},
+		{
+			title:        "Does not follow no-dco so it counts as normal label",
+			label:        "nodco",
+			expectedBool: false,
+		},
+		{
+			title:        "Normal label",
+			label:        "randomlabel",
+			expectedBool: false,
+		},
+	}
+
+	for _, test := range dcoLabel {
+		t.Run(test.label, func(t *testing.T) {
+			itsDco := isDcoLabel(test.label)
+			if itsDco != test.expectedBool {
+				t.Errorf("Wanted `%s` to return: %t but it returned:  %t.", test.label, test.expectedBool, itsDco)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Checks if the maintainer wants to remove no-dco label and if so it
prevents them from doing that.

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

Prevents maintainers to remove no-dco label with ```Derek remove label: no-dco```.

## Description
<!--- Describe your changes in detail -->

Added check if the label that the maintainer wants to remove is the ```no-dco``` and prevents them from removing it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))

Closes #85 .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Opened PR without sign off here https://github.com/martindekov/push2/pull/14 and no-dco was applied.

comment:
```
Derek remove label: NO-DCO
```
response:
```
martindekov wants to remove label of 'NO-DCO' on issue #14 
martindekov the request is not allowed.Label `NO-DCO` can be removed by owner or by signing out the commit.
```
comment:
```
Derek remove label: no-dco
```
response:
```
martindekov wants to remove label of 'no-dco' on issue #14 
martindekov the request is not allowed.Label `no-dco` can be removed by owner or by signing out the commit.
```
comment:
```
Derek remove label: nodco
```
response:
```
martindekov wants to remove label of 'nodco' on issue #14 
Request to remove label of 'nodco' on issue #14 was unnecessary.
```
comment:
```
Derek remove label: No-Dco
```
responce:
```
martindekov wants to remove label of 'No-Dco' on issue #14 
martindekov the request is not allowed.Label `No-Dco` can be removed by owner or by signing out the commit.
```
Note: For some unexpected reason the labels are parsed to lower even though i could not be able to find ```strings.ToLower()``` for label value.

...
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
