### PR TITLE
Turn on validate customers and hmac by default

### DIFF
--- a/auth/customers.go
+++ b/auth/customers.go
@@ -32,10 +32,8 @@ func buildCustomerURL() string {
 // IsCustomer returns true if a customer is listed in the customers file.
 // The validation is controlled by the 'validate_customers' env-var
 func IsCustomer(ownerLogin string, c *http.Client) (bool, error) {
-	validate := os.Getenv("validate_customers")
-
-	if len(validate) == 0 || (validate == "false" || validate == "0") {
-
+	validate := customerValidationEnabled()
+	if validate == false {
 		return true, nil
 	}
 
@@ -75,4 +73,9 @@ func IsCustomer(ownerLogin string, c *http.Client) (bool, error) {
 DO_RETURN:
 
 	return found, err
+}
+
+func customerValidationEnabled() bool {
+	validate := os.Getenv("validate_customers")
+	return validate != "false" && validate != "0"
 }

--- a/auth/customers_test.go
+++ b/auth/customers_test.go
@@ -47,3 +47,41 @@ func Test_findCustomerURL(t *testing.T) {
 		})
 	}
 }
+
+func Test_customerValidationEnabled(t *testing.T) {
+	tests := []struct {
+		title        string
+		value        string
+		expectedBool bool
+	}{
+		{
+			title:        "`validate_customers` is unset, defaults to on",
+			value:        "",
+			expectedBool: true,
+		},
+		{
+			title:        "`validate_customers` is set with random value, defaults to on",
+			value:        "random",
+			expectedBool: true,
+		},
+		{
+			title:        "`validate_customers` is set with explicit `0`",
+			value:        "0",
+			expectedBool: false,
+		},
+		{
+			title:        "`validate_customers` is set with explicit `false`",
+			value:        "false",
+			expectedBool: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			os.Setenv("validate_customers", test.value)
+			value := customerValidationEnabled()
+			if value != test.expectedBool {
+				t.Errorf("Expected value: %v got: %v", test.expectedBool, value)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -127,5 +127,5 @@ func getContributingURL(contributingURL, owner, repositoryName string) string {
 
 func hmacValidation() bool {
 	val := os.Getenv("validate_hmac")
-	return len(val) > 0 && (val == "1" || val == "true")
+	return (val != "false") && (val != "0")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -37,12 +37,40 @@ func Test_getContributingURL(t *testing.T) {
 	}
 }
 
-func Test_hmacValidationDefault(t *testing.T) {
-	os.Setenv("hmac_validation", "")
-	enabled := hmacValidation()
-	want := false
-	if enabled != want {
-		t.Errorf("want %t got %t", want, enabled)
-		t.Fail()
+func Test_customerValidation(t *testing.T) {
+	tests := []struct {
+		title        string
+		value        string
+		expectedBool bool
+	}{
+		{
+			title:        "`validate_hmac` is unset, defaults to on",
+			value:        "",
+			expectedBool: true,
+		},
+		{
+			title:        "`validate_hmac` is set with random value, defaults to on",
+			value:        "random",
+			expectedBool: true,
+		},
+		{
+			title:        "`validate_hmac` is set with explicit `0`",
+			value:        "0",
+			expectedBool: false,
+		},
+		{
+			title:        "`validate_hmac` is set with explicit `false`",
+			value:        "false",
+			expectedBool: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			os.Setenv("validate_hmac", test.value)
+			value := hmacValidation()
+			if value != test.expectedBool {
+				t.Errorf("Expected value: %v got: %v", test.expectedBool, value)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Setting the customer validation and hmac validation on by
default also moving customer validation into its own function
so it can be tested more easily and extending the tests
to showcase the logic the work was started by @ivanayov

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This adds more secure experience for the user so the hmac and security validation should now be turned off intentionally with explicit `false` or `0`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))

Actually part of [#316](https://github.com/openfaas/openfaas-cloud/issues/316) issue in OpenFaaS Cloud

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

For derek users with authentication turned off if they move to the newest version, they should explicitly set the `validate_customers: 0/false` and `validate_hmac:0/false`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
