### PR TITLE
Add namespace in secret creation

### DIFF
--- a/GET.md
+++ b/GET.md
@@ -74,8 +74,8 @@ $ docker secret create derek-secret-key derek-secret-key
 For Kubernetes:
 
 ```sh
-$ kubectl create secret generic derek-private-key --from-file=./derek-private-key
-$ kubectl create secret generic derek-secret-key --from-file=./derek-secret-key
+$ kubectl create secret generic derek-private-key --from-file=./derek-private-key -n openfaas-fn
+$ kubectl create secret generic derek-secret-key --from-file=./derek-secret-key -n openfaas-fn
 ```
 
 Create secrets.yml:


### PR DESCRIPTION
Adding namespace when creating the secret since
the command was invalid and misleading

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

`kubectl` command which creates secrets for derek was invalid (the namespace was missing)

## Description
<!--- Describe your changes in detail -->

Adding default `openfaas-fn` namespace to the `kubectl` commands which created the two secrets

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))

Didn't raise an issue due to the simplicity of the change

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
