### PR TITLE
Add comma separated multi labels facility

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,26 @@ Derek edit title: Question - does this work on Windows 10?
 
 Labels can be used to triage work or help sort it.
 
+To add a label:
 ```
 Derek add label: proposal
-Derek add label: help wanted
+```
+
+and to remove:
+```
 Derek remove label: bug
+```
+
+To address multiple labels through a single action use a comma separated list.
+
+To add multiple labels:
+```
+Derek add label: proposal, help wanted, skill/intermediate
+```
+
+and to remove:
+```
+Derek remove label: proposal, help wanted
 ```
 
 * Set milestones for issues

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -95,6 +95,18 @@ Derek add label: help wanted
 Derek remove label: bug
 ```
 
+To address multiple labels through a single action use a comma separated list.
+
+To add multiple labels:
+```
+Derek add label: proposal, help wanted, skill/intermediate
+```
+
+and to remove:
+```
+Derek remove label: proposal, help wanted
+```
+
 #### Set a milestone for an issue or PR
 
 You can organize your issues in groups through existing milestones


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
This change enables multiple labels to be applied through a single comment, by allowing for a comma separated list to be provided.  Also added plural aliases for the labels commands.

As the deletion of multiple labels is currently an iterative process, due to how the GitHub API is presented, an error could occur mid-flow when deleting and cause subsequent labels to not be applied. Mitigation against this is that labels are visually verifiable.

## Motivation and Context
Currently to add multiple labels a maintainer must add one comment for each label.  Members have found this confusing with some calling the command multiple times per comment.

 [x] I have raised an issue to propose this change (fixes #32, closes #110 )

## How Has This Been Tested?
Unit tests added.
Built Derek at `rgee0/derek:multiLabels`
Deployed locally
Tested on test repo - https://github.com/rgee0/Test/issues/7

![image](https://user-images.githubusercontent.com/16418793/52915521-05e3a400-32cd-11e9-9102-54954768aeb8.png)

![image](https://user-images.githubusercontent.com/16418793/52915513-e3518b00-32cc-11e9-8a67-ebfa29c3d0f1.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
