### PR TITLE
Add comma separated multi labels facility

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -79,6 +79,18 @@ Derek add label: help wanted
 Derek remove label: bug
 ```
 
+To address multiple labels through a single action use a comma separated list.  The maximum number of labels that can be managed in one comment defaults to 5; this can be set to preference through `multilabel_limit` in your `stack.yml`
+
+To add multiple labels:
+```
+Derek add label: proposal, help wanted, skill/intermediate
+```
+
+To remove multiple labels:
+```
+Derek remove label: proposal, help wanted
+```
+
 #### Set a milestone for an issue or PR
 
 You can organize your issues in groups through existing milestones
@@ -97,6 +109,9 @@ You can assign work to people too
 ```
 Derek assign: alexellis
 ```
+
+Use the `me` moniker to refer to yourself
+
 ```
 Derek unassign: me
 ```
@@ -107,6 +122,11 @@ You can assign people for a PR review as well
 
 ```
 Derek set reviewer: alexellis
+```
+
+Use the `me` moniker to refer to yourself
+
+```
 Derek clear reviewer: me
 ```
 

--- a/handler/commentHandler.go
+++ b/handler/commentHandler.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -35,8 +36,9 @@ const (
 	assignReviewerConstant   string = "AssignReviewer"
 	unassignReviewerConstant string = "UnassignReviewer"
 
-	commandTriggerDefault string = "Derek "
-	commandTriggerSlash   string = "/"
+	noDCO             string = "no-dco"
+	labelLimitDefault int    = 5
+	labelLimitEnvVar  string = "multilabel_limit"
 )
 
 func makeClient(installation int, config config.Config) (*github.Client, context.Context) {
@@ -135,40 +137,89 @@ func findLabel(currentLabels []types.IssueLabel, cmdLabel string) bool {
 	return false
 }
 
+func classifyLabels(currentLabels []types.IssueLabel, labelAction string, labelValue string) ([]string, []string) {
+
+	var actionableLabels, unactionableLabels []string
+
+	requestedLabels := strings.Split(labelValue, ",")
+
+	for _, requestedLabel := range requestedLabels {
+
+		requestedLabel = strings.TrimSpace(requestedLabel)
+
+		found := findLabel(currentLabels, requestedLabel)
+
+		if validAction(found, labelAction, addLabelConstant, removeLabelConstant) {
+			actionableLabels = append(actionableLabels, requestedLabel)
+		} else {
+			unactionableLabels = append(unactionableLabels, requestedLabel)
+		}
+
+	}
+	return actionableLabels, unactionableLabels
+}
+
 func manageLabel(req types.IssueCommentOuter, cmdType string, labelValue string, config config.Config) (string, error) {
 
 	var buffer bytes.Buffer
 	labelAction := strings.Replace(strings.ToLower(cmdType), "label", "", 1)
+	buffer.WriteString(fmt.Sprintf("%s wants to %s label(s) of '%s' on issue #%d.\n", req.Comment.User.Login, labelAction, labelValue, req.Issue.Number))
 
-	buffer.WriteString(fmt.Sprintf("%s wants to %s label of '%s' on issue #%d \n", req.Comment.User.Login, labelAction, labelValue, req.Issue.Number))
+	actionableLabels, unactionableLabels := classifyLabels(req.Issue.Labels, cmdType, labelValue)
 
-	found := findLabel(req.Issue.Labels, labelValue)
+	if len(unactionableLabels) > 0 {
+		buffer.WriteString(fmt.Sprintf("Request to %s label(s) of '%s' on issue #%d was unnecessary.\n", labelAction, strings.Join(unactionableLabels, ", "), req.Issue.Number))
 
-	if !validAction(found, cmdType, addLabelConstant, removeLabelConstant) {
-		buffer.WriteString(fmt.Sprintf("Request to %s label of '%s' on issue #%d was unnecessary.", labelAction, labelValue, req.Issue.Number))
-		return buffer.String(), nil
+		if len(actionableLabels) == 0 {
+			buffer.WriteString(fmt.Sprintf("No further valid labels found - no action taken on issue #%d.\n", req.Issue.Number))
+			return buffer.String(), nil
+		}
 	}
 
 	client, ctx := makeClient(req.Installation.ID, config)
 
 	var err error
 
+	maxActionableLabels := getMultiLabelLimit()
+
+	if len(actionableLabels) > maxActionableLabels {
+		buffer.WriteString(fmt.Sprintf("Label(s) '%s' on issue #%d were ignored as they fall outside of the configured limit of %d.\n", strings.Join(actionableLabels[maxActionableLabels:], ", "), req.Issue.Number, maxActionableLabels))
+		actionableLabels = actionableLabels[:maxActionableLabels]
+	}
+
 	if cmdType == addLabelConstant {
-		_, _, err = client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, []string{labelValue})
-	} else {
-		if isDcoLabel(labelValue) {
-			buffer.WriteString(fmt.Sprintf("%s the request is not allowed.Label `%s` can be removed by owner or by signing out the commit.", req.Repository.Owner.Login, labelValue))
-			return buffer.String(), nil
-		} else {
-			_, err = client.Issues.RemoveLabelForIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, labelValue)
+
+		_, _, err = client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, actionableLabels)
+
+		if err != nil {
+			return buffer.String(), err
 		}
+
+	} else {
+
+		actionedLabels := actionableLabels[:0]
+
+		for _, actionableLabel := range actionableLabels {
+
+			if isDcoLabel(actionableLabel) {
+
+				buffer.WriteString(fmt.Sprintf("The request to remove `%s` by %s was not allowed - label can be removed by owner or by signing off the commit.\n", actionableLabel, req.Repository.Owner.Login))
+
+			} else {
+
+				_, err = client.Issues.RemoveLabelForIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, actionableLabel)
+
+				if err != nil {
+					return buffer.String(), err
+				}
+
+				actionedLabels = append(actionedLabels, actionableLabel)
+			}
+		}
+		actionableLabels = actionedLabels
 	}
 
-	if err != nil {
-		return buffer.String(), err
-	}
-
-	buffer.WriteString(fmt.Sprintf("Request to %s label of '%s' on issue #%d was successfully completed.", labelAction, labelValue, req.Issue.Number))
+	buffer.WriteString(fmt.Sprintf("Request to %s label(s) of '%s' on issue #%d was successfully completed.\n", labelAction, strings.Join(actionableLabels, ", "), req.Issue.Number))
 	return buffer.String(), nil
 }
 
@@ -361,6 +412,8 @@ func parse(body string, commandTriggers []string) *types.CommentAction {
 		commands := map[string]string{
 			commandTrigger + "add label: ":        addLabelConstant,
 			commandTrigger + "remove label: ":     removeLabelConstant,
+			commandTrigger + "add labels: ":       addLabelConstant,
+			commandTrigger + "remove labels: ":    removeLabelConstant,
 			commandTrigger + "assign: ":           assignConstant,
 			commandTrigger + "unassign: ":         unassignConstant,
 			commandTrigger + "close":              closeConstant,
@@ -378,16 +431,22 @@ func parse(body string, commandTriggers []string) *types.CommentAction {
 		for trigger, commandType := range commands {
 
 			if isValidCommand(body, trigger) {
-				val := body[len(trigger):]
-				val = strings.Trim(val, " \t.,\n\r")
 				commentAction.Type = commandType
-				commentAction.Value = val
+				commentAction.Value = getCommandValue(body, len(trigger))
 				break
 			}
 		}
 	}
 
 	return &commentAction
+}
+
+func getCommandValue(commentBody string, triggerLength int) string {
+
+	val := commentBody[triggerLength:]
+	val = strings.Split(val, "\n")[0]
+	val = strings.Trim(val, " \t.,\n\r")
+	return val
 }
 
 func isValidCommand(body string, trigger string) bool {
@@ -428,9 +487,22 @@ func removeMilestone(client *github.Client, ctx context.Context, URL string) err
 }
 
 func isDcoLabel(labelValue string) bool {
-	return strings.ToLower(labelValue) == "no-dco"
+	return strings.ToLower(labelValue) == noDCO
 }
 
 func getCommandTriggers() []string {
 	return []string{"Derek ", "/"}
+}
+
+func getMultiLabelLimit() int {
+
+	val, ok := os.LookupEnv(labelLimitEnvVar)
+	if ok {
+		configuredLimit, err := strconv.Atoi(val)
+		if err != nil {
+			return labelLimitDefault
+		}
+		return configuredLimit
+	}
+	return labelLimitDefault
 }

--- a/stack.example.yml
+++ b/stack.example.yml
@@ -9,6 +9,7 @@ functions:
     lang: Dockerfile
     environment:
       application_id: <your_GH_applicationID>
+      multilabel_limit: 5
       debug: true
       customers_url: https://raw.githubusercontent.com/alexellis/derek/master/.CUSTOMERS
       validate_hmac: false


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
This change enables multiple labels to be applied through a single comment, by allowing for a comma separated list to be provided.  Also added plural aliases for the labels commands.

This change also introduces a new env var which limits how many labels can be processed in a single command.  This defaults to 5 but can be set to preference through `multilabel_limit`.  An example has been included in the `stack.example.yml`. A test has been added for the function which retrieves this value from the env vars.

As the requested labels are pre-processed to ascertain which are actionable and which are not given the requested action, the limit will be applied to the first _n_ actionable labels, rather than the first _n_ requested labels.

As the deletion of multiple labels is currently an iterative process - due to how the GitHub API is presented - an error could occur mid-flow when deleting and cause subsequent labels to not be applied. Mitigation against this is that labels are visually verifiable.

## Motivation and Context
Currently to add multiple labels a maintainer must add one comment for each label.  Members have found this confusing with some calling the command multiple times per comment.

 [x] I have raised an issue to propose this change (fixes #32, closes #110 )

## How Has This Been Tested?
Unit tests added.
Built Derek at `rgee0/derek:multiLabels`
Deployed locally
Tested on test repo - https://github.com/rgee0/Test/issues/8

```
environment:
      application_id: 6184
      debug: true
      customers_url: https://raw.githubusercontent.com/alexellis/derek/master/.CUSTOMERS
      validate_hmac: false
      validate_customers: true
      secret_path: /var/openfaas/secrets/ # use /run/secrets/ for older OpenFaaS versions
```
![image](https://user-images.githubusercontent.com/16418793/52919569-9e911880-32fb-11e9-8b6d-cb5c1f50a0d9.png)

```
environment:
      application_id: 6184
      multilabel_limit: 3
      debug: true
      customers_url: https://raw.githubusercontent.com/alexellis/derek/master/.CUSTOMERS
      validate_hmac: false
      validate_customers: true
      secret_path: /var/openfaas/secrets/ # use /run/secrets/ for older OpenFaaS versions
```
![image](https://user-images.githubusercontent.com/16418793/52919276-a8654c80-32f8-11e9-8aff-b843d395c5f3.png)

```
environment:
      application_id: 6184
      multilabel_limit: 3
      debug: true
      customers_url: https://raw.githubusercontent.com/alexellis/derek/master/.CUSTOMERS
      validate_hmac: false
      validate_customers: true
      secret_path: /var/openfaas/secrets/ # use /run/secrets/ for older OpenFaaS versions
```
![image](https://user-images.githubusercontent.com/16418793/52919491-e82d3380-32fa-11e9-9946-fea00c799d20.png)

## updated tests to cover handling of newlines

![image](https://user-images.githubusercontent.com/16418793/52970293-3bf75580-33ab-11e9-97fc-a48f75cb7971.png)

![image](https://user-images.githubusercontent.com/16418793/52970265-22eea480-33ab-11e9-8aa4-56c6f888bb87.png)

![image](https://user-images.githubusercontent.com/16418793/52970323-55000680-33ab-11e9-9b5f-4608b94c1cae.png)

![image](https://user-images.githubusercontent.com/16418793/52970355-706b1180-33ab-11e9-8e3a-b4bacfdc2fc9.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
