### PR TITLE
Check if commit was signed by an anonymous email

### DIFF
--- a/handler/pullRequestHandler.go
+++ b/handler/pullRequestHandler.go
@@ -78,12 +78,9 @@ func HandlePullRequest(req types.PullRequestOuter, contributingURL string, confi
 
 	var body string
 	if anonymousSign {
-		body =
-			`Thank you for your contribution. It seems that one or more of your commits have an anonymous email address. Please consider signing your commits with a valid email address. Please see our [contributing guide](` + contributingURL + `).`
+		body = anonymousCommitComment(contributingURL)
 	} else {
-		body =
-			`Thank you for your contribution. I've just checked and your commit doesn't appear to be signed-off. That's something we need before your Pull Request can be merged. Please see our [contributing guide](` + contributingURL + `).
-Tip: if you only have one commit so far then run: ` + "`" + `git commit --amend --sign-off` + "`" + ` and then ` + "`" + `git push --force` + "`."
+		body = unsignedCommitComment(contributingURL)
 	}
 
 	if !noDcoLabelExists {
@@ -124,8 +121,7 @@ func VerifyPullRequestDescription(req types.PullRequestOuter, contributingURL st
 				log.Fatalf("%s limit: %d, remaining: %d", assignLabelErr, res.Limit, res.Remaining)
 			}
 
-			body := `Thank you for your contribution. I've just checked and your Pull Request doesn't appear to have any description.
-That's something we need before your Pull Request can be merged. Please see our [contributing guide](` + contributingURL + `).`
+			body := emptyDescriptionComment(contributingURL)
 
 			comment := &github.IssueComment{
 				Body: &body,
@@ -139,6 +135,20 @@ That's something we need before your Pull Request can be merged. Please see our 
 			fmt.Println(comment, resp.Rate)
 		}
 	}
+}
+
+func anonymousCommitComment(contributingURL string) string {
+	return `Thank you for your contribution. It seems that one or more of your commits have an anonymous email address. Please consider signing your commits with a valid email address. Please see our [contributing guide](` + contributingURL + `).`
+}
+
+func unsignedCommitComment(contributingURL string) string {
+	return `Thank you for your contribution. I've just checked and your commit doesn't appear to be signed-off. That's something we need before your Pull Request can be merged. Please see our [contributing guide](` + contributingURL + `).
+Tip: if you only have one commit so far then run: ` + "`" + `git commit --amend --sign-off` + "`" + ` and then ` + "`" + `git push --force` + "`."
+}
+
+func emptyDescriptionComment(contributingURL string) string {
+	return `Thank you for your contribution. I've just checked and your Pull Request doesn't appear to have any description.
+That's something we need before your Pull Request can be merged. Please see our [contributing guide](` + contributingURL + `).`
 }
 
 func getAccessToken(config config.Config, installationID int) (string, error) {

--- a/handler/pullRequestHandler_test.go
+++ b/handler/pullRequestHandler_test.go
@@ -187,6 +187,17 @@ func Test_hasAnonymousSign(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			title: "Has an unsigned commit",
+			commits: []*github.RepositoryCommit{
+				&github.RepositoryCommit{
+					Commit: &github.Commit{
+						Message: stringPtr("Commit message"),
+					},
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for _, test := range anonymousSignOpts {


### PR DESCRIPTION
Signed-off-by: Matias Pan <matias.pan26@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
This PR adds a check for when commits have an anonymous email address.

## Description
<!--- Describe your changes in detail -->
If at least one of the commits was signed with an email address that ends in `noreply.github.com` then we reply with a different comment that asks for the commit to be properly signed. This is comment that we are using(it can be changed :smile: ): 
> Thank you for your contribution. It seems that one or more of your commits have an anonymous email address. Please consider signing your commits with a valid email address. Please see our [contributing guide](https://github.com/matipan/test-derek/blob/master/CONTRIBUTING.md).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change (Fixes #118)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests for new functionality
I built derek at `matipan/derek:anonymousCheck`, deployed it on my personal cluster and tested it using the following repository: [matipan/test-derek](https://github.com/matipan/test-derek)
Derek in action:
![derek-dco-invalid-email](https://user-images.githubusercontent.com/8126891/53193751-903f4700-35f0-11e9-9d74-e42ce7d1168e.png)
Existing behavior was not changed:
![derek-dco-unsigned](https://user-images.githubusercontent.com/8126891/53193795-acdb7f00-35f0-11e9-9e29-044010a4927f.png)
![derek-dco-valid](https://user-images.githubusercontent.com/8126891/53193799-aea54280-35f0-11e9-8f4a-1cdc480fe5a4.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
