### PR TITLE
Correct --sign-off to --signoff in bot feedback

### DIFF
--- a/GET.md
+++ b/GET.md
@@ -25,7 +25,7 @@ You can use this file as a template: https://github.com/openfaas/faas/blob/maste
 
 * Now raise a PR to the `.CUSTOMERS` file
 
-Raise a PR to this file, and make sure you use `git commit --sign-off` rather than the UI to make the PR
+Raise a PR to this file, and make sure you use `git commit --signoff` rather than the UI to make the PR
 
 https://github.com/alexellis/derek/blob/master/.CUSTOMERS
 

--- a/handler/pullRequestHandler.go
+++ b/handler/pullRequestHandler.go
@@ -143,7 +143,7 @@ func anonymousCommitComment(contributingURL string) string {
 
 func unsignedCommitComment(contributingURL string) string {
 	return `Thank you for your contribution. I've just checked and your commit doesn't appear to be signed-off. That's something we need before your Pull Request can be merged. Please see our [contributing guide](` + contributingURL + `).
-Tip: if you only have one commit so far then run: ` + "`" + `git commit --amend --sign-off` + "`" + ` and then ` + "`" + `git push --force` + "`."
+Tip: if you only have one commit so far then run: ` + "`" + `git commit --amend --signoff` + "`" + ` and then ` + "`" + `git push --force` + "`."
 }
 
 func emptyDescriptionComment(contributingURL string) string {


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Amends references to `--sign-off` with `--signoff` as per git client help.
```
       -s, --signoff
           Add Signed-off-by line by the committer at the end of the commit log message. The meaning of a signoff depends
           on the project, but it typically certifies that committer has the rights to submit this work under the same
           license and agrees to a Developer Certificate of Origin (see http://developercertificate.org/ for more
           information).
```

## Motivation and Context
The message was wrong.  It's now correct.  Also updated the GET.md reference.


## How Has This Been Tested?
Trivial non-invasive change

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
