### PR TITLE
Turn down the verbosity of the messages feature response

### DIFF
--- a/handler/commentHandler.go
+++ b/handler/commentHandler.go
@@ -527,16 +527,16 @@ func createMessage(req types.IssueCommentOuter, cmdType, cmdValue string, config
 		return buffer.String(), fmt.Errorf("Error while filtering message: %s", err.Error())
 	}
 
-	buffer.WriteString(fmt.Sprintf("Message '%s' with content: \n%s\nfound.\n", cmdValue, *messageValue.Body))
+	buffer.WriteString(fmt.Sprintf("Message '%s' found.\n", cmdValue))
 
 	client, ctx := makeClient(req.Installation.ID, config)
 
-	comment, resp, err := client.Issues.CreateComment(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, messageValue)
+	_, resp, err := client.Issues.CreateComment(ctx, req.Repository.Owner.Login, req.Repository.Name, req.Issue.Number, messageValue)
 	if err != nil {
 		return buffer.String(), err
 	}
-	buffer.WriteString(fmt.Sprintf("Successfully applied comment: \n%s\nstatus code: %d",
-		*comment.Body,
+	buffer.WriteString(fmt.Sprintf("Successfully applied message: `%s` status code: %d\n",
+		cmdValue,
 		resp.StatusCode))
 
 	return buffer.String(), nil


### PR DESCRIPTION
Turning down the verbosity of the new messages feature
as it was too long. The commit removes the body of the
message leaving only the name of the message to be applied

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Response has the value of the message removed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))
- [x] Requested

The old response included the message content and its name, now it has only the message name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually, the response is now:
On success:
![image](https://user-images.githubusercontent.com/34942004/61592762-18e20380-abe0-11e9-9e0f-a1f440d5e68d.png)
On failure(the same):
![image](https://user-images.githubusercontent.com/34942004/61592769-3747ff00-abe0-11e9-9080-ea810572d6a7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Response trim
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
