### PR TITLE
Add Hacktoberfest feature

### DIFF
--- a/handler/pullRequestHandler.go
+++ b/handler/pullRequestHandler.go
@@ -26,6 +26,42 @@ const (
 
 var anonymousSign = regexp.MustCompile("Signed-off-by:(.*)noreply.github.com")
 
+// HandleHacktoberfestPR checks for opened PR, first time contributor. If only .MD files are changed, issue is closed and invalid label is added
+// The goal of this function is to mark pull requests invalid and close them from people only making typo changes without signing their commit (flybys)
+func HandleHacktoberfestPR(req types.PullRequestOuter, contributingURL string, config config.Config) {
+	ctx := context.Background()
+	token, tokenErr := getAccessToken(config, req.Installation.ID)
+
+	if tokenErr != nil {
+		fmt.Printf("Error getting installation token: %s\n", tokenErr.Error())
+		return
+	}
+
+	client := factory.MakeClient(ctx, token, config)
+
+	if req.Action == openedPRAction {
+
+		if isHacktoberfestSpam(req, client) {
+			_, res, assignLabelErr := client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, []string{"invalid"})
+			if assignLabelErr != nil {
+				log.Fatalf("%s limit: %d, remaining: %d", assignLabelErr, res.Limit, res.Remaining)
+			}
+
+			closeState := "close"
+			input := &github.IssueRequest{State: &closeState}
+
+			_, _, err := client.Issues.Edit(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, input)
+			if err != nil {
+				log.Fatalf("unable to close pull request %d: %s", req.PullRequest.Number, err)
+				return
+			}
+
+			fmt.Println(fmt.Sprintf("Request to close issue #%d was successful.\n", req.PullRequest.Number))
+			return
+		}
+	}
+}
+
 func HandlePullRequest(req types.PullRequestOuter, contributingURL string, config config.Config) {
 	ctx := context.Background()
 	token, tokenErr := getAccessToken(config, req.Installation.ID)
@@ -243,4 +279,36 @@ func isSigned(msg string) bool {
 
 func hasDescription(pr types.PullRequest) bool {
 	return len(strings.TrimSpace(pr.Body)) > 0
+}
+
+func isHacktoberfestSpam(req types.PullRequestOuter, client *github.Client) bool {
+	commits, err := fetchPullRequestCommits(req, client)
+	if err != nil {
+		log.Fatalf("unable to fetch pull request commits for PR %d: %s", req.PullRequest.Number, err)
+		return false
+	}
+
+	anonymousSign := hasAnonymousSign(commits)
+	unsignedCommits := hasUnsigned(commits)
+
+	onlyMD := onlyMarkdownFiles(commits)
+
+	return onlyMD && req.PullRequest.FirstTimeContributor() && (anonymousSign || unsignedCommits)
+}
+
+func onlyMarkdownFiles(commits []*github.RepositoryCommit) bool {
+	for _, c := range commits {
+		if len(c.Files) == 0 {
+			return false
+		}
+
+		for _, f := range c.Files {
+			fileName := f.GetFilename()
+			ext := fileName[strings.LastIndex(fileName, ".")+1:]
+			if !strings.EqualFold(ext, "md") {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/handler/pullRequestHandler.go
+++ b/handler/pullRequestHandler.go
@@ -57,6 +57,13 @@ func HandleHacktoberfestPR(req types.PullRequestOuter, contributingURL string, c
 			}
 
 			fmt.Println(fmt.Sprintf("Request to close issue #%d was successful.\n", req.PullRequest.Number))
+
+			body := hacktoberfestSpamComment(contributingURL)
+
+			if err = createPullRequestComment(ctx, body, req, client); err != nil {
+				log.Fatalf("unable to add comment on PR %d: %s", req.PullRequest.Number, err)
+			}
+
 			return
 		}
 	}
@@ -185,6 +192,12 @@ Tip: if you only have one commit so far then run: ` + "`" + `git commit --amend 
 func emptyDescriptionComment(contributingURL string) string {
 	return `Thank you for your contribution. I've just checked and your Pull Request doesn't appear to have any description.
 That's something we need before your Pull Request can be merged. Please see our [contributing guide](` + contributingURL + `).`
+}
+
+func hacktoberfestSpamComment(contributingURL string) string {
+	return `Thank you for your contribution. I've checked and your commit does not appear to follow the guidelines in our [contributing guide](` + contributingURL + `). Spelling and README changes are better handled by opening an issue.
+Also, be sure to review the Hacktoberfest [quality standards](https://hacktoberfest.digitalocean.com/details#quality-standards)
+`
 }
 
 func getAccessToken(config config.Config, installationID int) (string, error) {

--- a/handler/pullRequestHandler_test.go
+++ b/handler/pullRequestHandler_test.go
@@ -216,74 +216,55 @@ func Test_onlyMarkdownFiles(t *testing.T) {
 	nonMDFileName := "main.go"
 
 	var testCommits = []struct {
-		commits  []*github.RepositoryCommit
+		files    []*github.CommitFile
 		expected bool
 	}{
 		{
-			commits: []*github.RepositoryCommit{
-				&github.RepositoryCommit{
-					Files: []github.CommitFile{
-						github.CommitFile{
-							Filename: &mdFileName1,
-						},
-					},
+			files: []*github.CommitFile{
+				&github.CommitFile{
+					Filename: &mdFileName1,
 				},
 			},
 			expected: true,
 		},
 		{
-			commits: []*github.RepositoryCommit{
-				&github.RepositoryCommit{
-					Files: []github.CommitFile{
-						github.CommitFile{
-							Filename: &mdFileName2,
-						},
-					},
+			files: []*github.CommitFile{
+				&github.CommitFile{
+					Filename: &mdFileName2,
 				},
 			},
 			expected: true,
 		},
 		{
-			commits: []*github.RepositoryCommit{
-				&github.RepositoryCommit{
-					Files: []github.CommitFile{
-						github.CommitFile{
-							Filename: &mdFileName1,
-						},
-						github.CommitFile{
-							Filename: &mdFileName2,
-						},
-					},
+			files: []*github.CommitFile{
+				&github.CommitFile{
+					Filename: &mdFileName1,
+				},
+				&github.CommitFile{
+					Filename: &mdFileName2,
 				},
 			},
 			expected: true,
 		},
 		{
-			commits: []*github.RepositoryCommit{
-				&github.RepositoryCommit{
-					Files: []github.CommitFile{
-						github.CommitFile{
-							Filename: &nonMDFileName,
-						},
-					},
+			files: []*github.CommitFile{
+				&github.CommitFile{
+					Filename: &nonMDFileName,
 				},
 			},
 			expected: false,
 		},
 		{
-			commits: []*github.RepositoryCommit{
-				&github.RepositoryCommit{
-					Files: []github.CommitFile{
-						github.CommitFile{
-							Filename: &mdFileName1,
-						},
-						github.CommitFile{
-							Filename: &mdFileName2,
-						},
-						github.CommitFile{
-							Filename: &nonMDFileName,
-						},
-					},
+
+			files: []*github.CommitFile{
+				&github.CommitFile{
+					Filename: &mdFileName1,
+				},
+				&github.CommitFile{
+					Filename: &mdFileName2,
+				},
+				&github.CommitFile{
+					Filename: &nonMDFileName,
 				},
 			},
 			expected: false,
@@ -291,7 +272,7 @@ func Test_onlyMarkdownFiles(t *testing.T) {
 	}
 
 	for _, test := range testCommits {
-		onlyMD := onlyMarkdownFiles(test.commits)
+		onlyMD := onlyMarkdownFiles(test.files)
 		if onlyMD != test.expected {
 			t.Errorf("Only markdown files - wanted %t, found %t", test.expected, onlyMD)
 		}

--- a/handler/pullRequestHandler_test.go
+++ b/handler/pullRequestHandler_test.go
@@ -210,6 +210,94 @@ func Test_hasAnonymousSign(t *testing.T) {
 	}
 }
 
+func Test_onlyMarkdownFiles(t *testing.T) {
+	mdFileName1 := "readme.md"
+	mdFileName2 := "README.MD"
+	nonMDFileName := "main.go"
+
+	var testCommits = []struct {
+		commits  []*github.RepositoryCommit
+		expected bool
+	}{
+		{
+			commits: []*github.RepositoryCommit{
+				&github.RepositoryCommit{
+					Files: []github.CommitFile{
+						github.CommitFile{
+							Filename: &mdFileName1,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			commits: []*github.RepositoryCommit{
+				&github.RepositoryCommit{
+					Files: []github.CommitFile{
+						github.CommitFile{
+							Filename: &mdFileName2,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			commits: []*github.RepositoryCommit{
+				&github.RepositoryCommit{
+					Files: []github.CommitFile{
+						github.CommitFile{
+							Filename: &mdFileName1,
+						},
+						github.CommitFile{
+							Filename: &mdFileName2,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			commits: []*github.RepositoryCommit{
+				&github.RepositoryCommit{
+					Files: []github.CommitFile{
+						github.CommitFile{
+							Filename: &nonMDFileName,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			commits: []*github.RepositoryCommit{
+				&github.RepositoryCommit{
+					Files: []github.CommitFile{
+						github.CommitFile{
+							Filename: &mdFileName1,
+						},
+						github.CommitFile{
+							Filename: &mdFileName2,
+						},
+						github.CommitFile{
+							Filename: &nonMDFileName,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range testCommits {
+		onlyMD := onlyMarkdownFiles(test.commits)
+		if onlyMD != test.expected {
+			t.Errorf("Only markdown files - wanted %t, found %t", test.expected, onlyMD)
+		}
+	}
+}
+
 func stringPtr(s string) *string {
 	return &s
 }

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ const (
 	comments              = "comments"
 	deleted               = "deleted"
 	prDescriptionRequired = "pr_description_required"
+	hacktoberfest         = "hacktoberfest"
 )
 
 func main() {
@@ -90,6 +91,9 @@ func handleEvent(eventType string, bytesIn []byte, config config.Config) error {
 		}
 		if req.Action != handler.ClosedConstant {
 			contributingURL := getContributingURL(derekConfig.ContributingURL, req.Repository.Owner.Login, req.Repository.Name)
+			if handler.EnabledFeature(hacktoberfest, derekConfig) {
+				handler.HandleHacktoberfestPR(req, contributingURL, config)
+			}
 			if handler.EnabledFeature(dcoCheck, derekConfig) {
 				handler.HandlePullRequest(req, contributingURL, config)
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This change adds the new feature `hacktoberfest`
The goal of this feature is to find flyby pull requests
that are considered spam.
A pull request that is a first time contributor, not signed,
and only changing markdown (md) files is assumed to be spam.
If the contributor has read the contribution guide, they
would have signed their commit, and the handler would have
no affect.
Otherwise, the pull request is closed, and an invalid
label is added indicating that this PR should not be counted

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))
Discussed with Alex via Slack


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests to verify the "markdown only" function works as expected. 

Unfortunately, I was unable to deploy and test as my deployment of Derek was not able to access the secret for some reason. I've run out of time this evening to debug further.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

We can update the documentation once this feature passes an Alpha/Beta phase of testing
