### PR TITLE
Add 1 min safety window for commit listing

### DIFF
--- a/handler/release_handler_test.go
+++ b/handler/release_handler_test.go
@@ -153,3 +153,53 @@ func Test_getWorkingReleases_OneRelease(t *testing.T) {
 	}
 
 }
+
+func Test_includeCommit_AfterCurrentPeriod(t *testing.T) {
+	now := time.Now()
+
+	cmDate := now.Add(time.Hour * 48)
+	cm := github.RepositoryCommit{
+		Commit: &github.Commit{
+			Committer: &github.CommitAuthor{
+				Date: &cmDate,
+			},
+		},
+	}
+
+	previous := now.Add(time.Hour * -24)
+	current := now.Add(time.Hour * 24)
+
+	got := includeCommits(cm, previous, current)
+	want := false
+
+	if got != want {
+		t.Errorf("Included value for Commot %s incorrect for range: [%s-%s] got: %v, want %v",
+			cm.GetCommit().GetCommitter().GetDate().String(), previous.String(), current.String(), got, want)
+		t.Fail()
+	}
+}
+
+func Test_includeCommit_WithinCurrentRange(t *testing.T) {
+	now := time.Now()
+
+	cmDate := now.Add(time.Hour)
+	cm := github.RepositoryCommit{
+		Commit: &github.Commit{
+			Committer: &github.CommitAuthor{
+				Date: &cmDate,
+			},
+		},
+	}
+
+	previous := now.Add(time.Hour * -24)
+	current := now.Add(time.Hour * 24)
+
+	got := includeCommits(cm, previous, current)
+	want := true
+	t.Logf("Running Test Case")
+	if got != want {
+		t.Errorf("Included value for Commit %s incorrect for range: [%s-%s] got: %v, want %v",
+			cm.GetCommit().GetCommitter().GetDate().String(), previous.String(), current.String(), got, want)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add 1 min safety window for commit listing
## Description
<!--- Describe your changes in detail -->
building a new function includeCommits() based on includePR()
which adds 1 min safety window for commit listing.
This will help Derek to avoid including commits from prior
releases.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] Add 1 min safety window for commit listing ([required](https://github.com/alexellis/derek/issues/143))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run `./build.sh` to build and run all the test cases in the docker image
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
