### PR TITLE
Fix typo in removing deprecated api endpoint

### DIFF
--- a/auth/jwt_auth.go
+++ b/auth/jwt_auth.go
@@ -52,7 +52,7 @@ func MakeAccessTokenForInstallation(appID string, installation int, privateKey s
 
 	if err == nil {
 		c := http.Client{}
-		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("https://api.github.com/apps/installations/%d/access_tokens", installation), nil)
+		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("https://api.github.com/app/installations/%d/access_tokens", installation), nil)
 
 		req.Header.Add("Authorization", "Bearer "+signed)
 		req.Header.Add("Accept", "application/vnd.github.machine-man-preview+json")
@@ -72,9 +72,10 @@ func MakeAccessTokenForInstallation(appID string, installation int, privateKey s
 				return "", jsonErr
 			}
 
-			return string(jwtAuth.Token), nil
+			return jwtAuth.Token, nil
 		}
 	}
+	fmt.Println(fmt.Sprintf("Clound not get access token, %v", err))
 
 	return "", err
 }

--- a/handler/pullrequest_handler.go
+++ b/handler/pullrequest_handler.go
@@ -101,12 +101,12 @@ func HandlePullRequest(req types.PullRequestOuter, contributingURL string, confi
 
 		_, res, assignLabelErr := client.Issues.AddLabelsToIssue(ctx, req.Repository.Owner.Login, req.Repository.Name, req.PullRequest.Number, []string{"no-dco"})
 		if assignLabelErr != nil {
-			log.Fatalf("unable to add DCO label to PR %d: %s", req.PullRequest.Number, err)
+			log.Fatalf("unable to add DCO label to PR %d: %v", req.PullRequest.Number, assignLabelErr)
 		}
 		fmt.Println("Rate limiting", res.Rate)
 
 		if err = createPullRequestComment(ctx, body, req, client); err != nil {
-			log.Fatalf("unable to add comment on PR %d: %s", req.PullRequest.Number, err)
+			log.Fatalf("unable to add comment on PR %d: %v", req.PullRequest.Number, err)
 		}
 	} else {
 		fmt.Printf("[%s/%s] DCO label already applied: PR: %d\n",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Github deprecated and api endpoint for auth tokens on apps, I previously
typed `apps/` and it should have been `app/`

This has been tested by running the broken container, verifying that it
did not work, then changing the `apps` to `app` and re-deploying - then
invoking a change on github that sent webhooks to my installation. After
the fix it worked, was given the 5k/hr rate limit and correctly added /
removed labels from PRs.


There are also some logging improvements and the wrong error was being used for one of the print statements.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md))
#156 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see commit message and text above
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
