### PR TITLE
Force local headings to over-ride remote

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -274,3 +274,5 @@ You can specify a `redirect` URL in the .DEREK.yml file, this instructs derek to
 apply local overrides and additions to the config set in the remote file.
 
 For example, to add a contributor to that repo (in addition to the existing contributors) you can specify the remote file and also add the `maintainers` section to your local file. These lists will then be merged, giving all users in the merged set access to derek.
+
+The exception to the rule in the merging of configs is in the `required_in_issues` feature where the locally configured values will fully override any and all values set in the remote config.

--- a/types/merge.go
+++ b/types/merge.go
@@ -11,5 +11,9 @@ func MergeDerekRepoConfigs(localConfig, remoteConfig DerekRepoConfig) (DerekRepo
 		return remoteConfig, mergeErr
 	}
 
+	if len(localConfig.RequiredInIssues) > 0 {
+		remoteConfig.RequiredInIssues = localConfig.RequiredInIssues
+	}
+
 	return remoteConfig, nil
 }

--- a/types/merge_test.go
+++ b/types/merge_test.go
@@ -78,3 +78,27 @@ func Test_mergeDerekRepoConfigs_ConfigValuesAppendedToList(t *testing.T) {
 	}
 
 }
+
+func Test_mergeDerekRepoConfigs_UseLocalHeadings(t *testing.T) {
+
+	remote := DerekRepoConfig{
+		RequiredInIssues: []string{
+			"#1",
+			"#2",
+		},
+	}
+	local := DerekRepoConfig{
+		RequiredInIssues: []string{
+			"#2",
+		},
+	}
+
+	got, err := MergeDerekRepoConfigs(local, remote)
+
+	if err != nil {
+		t.Errorf("Got error for a single plan, expected no error: %s", err.Error())
+	}
+	if len(got.RequiredInIssues) != len(local.RequiredInIssues) {
+		t.Errorf("RequiredInIssues want %s, but got %s", local.RequiredInIssues, got.RequiredInIssues)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
The intended mode of operation for the Issue template headings was
for the local to over-ride the remote.  This is different to the other
fields, such as maintainers.

This change adds the test to highlight the issue and addresses the
issue in MergeDerekRepoConfigs.

## Motivation and Context
A recent issue (https://github.com/alexellis/go-execute/issues/10)
indirectly highlighted that the merging of local and remote configs
was producing a superset which included duplicate headings

## How Has This Been Tested?
Wrote the test, and ran it:
```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^Test_mergeDerekRepoConfigs_UseLocalHeadings$ github.com/alexellis/derek/types

--- FAIL: Test_mergeDerekRepoConfigs_UseLocalHeadings (0.00s)
    /Users/rgee0/go/src/github.com/alexellis/derek/types/merge_test.go:102: RequiredInIssues want [#2], but got [#1 #2 #2]
FAIL
FAIL    github.com/alexellis/derek/types    0.229s
FAIL
```
Note the `got` set is a merge of the remote and local so includes `#2` twice.

Amended `MergeDerekRepoConfigs()` so that if `required_in_issue` is set locally then those values will take precedence. 
Re-ran the test:
```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^Test_mergeDerekRepoConfigs_UseLocalHeadings$ github.com/alexellis/derek/types

ok  	github.com/alexellis/derek/types	0.233s
```
Ran a build using the Dockerfile.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/derek/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
